### PR TITLE
Fix: Dead loop when reading an empty .osu file.

### DIFF
--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -604,9 +604,7 @@ macro_rules! parse_body {
         let mut reader = $reader::new($input);
         let mut buf = String::new();
 
-        loop {
-            read_line!(reader, &mut buf)?;
-
+        while read_line!(reader, &mut buf)? != 0 {
             // Check for character U+FEFF specifically thanks to map id 797130
             if !buf
                 .trim_matches(|c: char| c.is_whitespace() || c == '﻿')


### PR DESCRIPTION
Fix: Dead loop when reading an empty .osu file.