### PR TITLE
don't read file into a string buffer to parse

### DIFF
--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -26,8 +26,6 @@ pub enum ParseError {
     InvalidInteger,
     /// Failed to parse game mode.
     InvalidMode,
-    /// Line contained invalid UTF-8
-    InvalidUtf8,
     /// Expected an additional field.
     MissingField(&'static str),
     /// Reject maps with too many repeat points.
@@ -48,7 +46,6 @@ impl fmt::Display for ParseError {
             Self::InvalidInteger => f.write_str("invalid integer"),
             Self::InvalidDecimalNumber => f.write_str("invalid float number"),
             Self::InvalidMode => f.write_str("invalid mode"),
-            Self::InvalidUtf8 => f.write_str("invalid UTF-8"),
             Self::MissingField(field) => write!(f, "missing field `{}`", field),
             Self::TooManyRepeats => f.write_str("repeat count is way too high"),
             Self::UnknownHitObjectKind => f.write_str("unsupported hitobject kind"),
@@ -66,7 +63,6 @@ impl StdError for ParseError {
             Self::InvalidInteger => None,
             Self::InvalidDecimalNumber => None,
             Self::InvalidMode => None,
-            Self::InvalidUtf8 => None,
             Self::MissingField(_) => None,
             Self::TooManyRepeats => None,
             Self::UnknownHitObjectKind => None,

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -1,5 +1,3 @@
-use super::OSU_FILE_HEADER;
-
 use std::{
     error::Error as StdError,
     fmt,
@@ -41,7 +39,7 @@ impl fmt::Display for ParseError {
         match self {
             Self::IOError(_) => f.write_str("IO error"),
             Self::IncorrectFileHeader => {
-                write!(f, "expected `{}` at file begin", OSU_FILE_HEADER)
+                write!(f, "expected `osu file format v` at file begin")
             }
             Self::BadLine => f.write_str("line not in `Key:Value` pattern"),
             Self::InvalidCurvePoints => f.write_str("invalid curve point"),

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -26,6 +26,8 @@ pub enum ParseError {
     InvalidInteger,
     /// Failed to parse game mode.
     InvalidMode,
+    /// Line contained invalid UTF-8
+    InvalidUtf8,
     /// Expected an additional field.
     MissingField(&'static str),
     /// Reject maps with too many repeat points.
@@ -46,6 +48,7 @@ impl fmt::Display for ParseError {
             Self::InvalidInteger => f.write_str("invalid integer"),
             Self::InvalidDecimalNumber => f.write_str("invalid float number"),
             Self::InvalidMode => f.write_str("invalid mode"),
+            Self::InvalidUtf8 => f.write_str("invalid UTF-8"),
             Self::MissingField(field) => write!(f, "missing field `{}`", field),
             Self::TooManyRepeats => f.write_str("repeat count is way too high"),
             Self::UnknownHitObjectKind => f.write_str("unsupported hitobject kind"),
@@ -63,6 +66,7 @@ impl StdError for ParseError {
             Self::InvalidInteger => None,
             Self::InvalidDecimalNumber => None,
             Self::InvalidMode => None,
+            Self::InvalidUtf8 => None,
             Self::MissingField(_) => None,
             Self::TooManyRepeats => None,
             Self::UnknownHitObjectKind => None,

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -4,6 +4,7 @@ mod error;
 mod hitobject;
 mod hitsound;
 mod pos2;
+mod reader;
 mod sort;
 
 pub use attributes::BeatmapAttributes;
@@ -17,10 +18,7 @@ use sort::legacy_sort;
 use std::cmp::Ordering;
 
 #[cfg(not(any(feature = "async_std", feature = "async_tokio")))]
-use std::{
-    fs::File,
-    io::{BufRead, BufReader, Read},
-};
+use std::{fs::File, io::Read};
 
 #[cfg(feature = "async_tokio")]
 use tokio::{
@@ -39,6 +37,8 @@ use async_std::{
 };
 
 pub use slider_parsing::*;
+
+use reader::FileReader;
 
 fn sort_unstable<T: PartialOrd>(slice: &mut [T]) {
     slice.sort_unstable_by(|p1, p2| p1.partial_cmp(p2).unwrap_or(Ordering::Equal));
@@ -66,70 +66,50 @@ impl FloatExt for f64 {
     }
 }
 
-macro_rules! line_prepare {
-    ($buf:ident) => {{
-        let mut line = $buf.trim_end();
-
-        if skip_line(line) {
-            $buf.clear();
-            continue;
-        }
-
-        if let Some(idx) = line.find("//") {
-            line = &line[..idx];
-        }
-
-        line
-    }};
-}
-
 macro_rules! section {
-    ($map:ident, $func:ident, $reader:ident, $buf:ident, $section:ident) => {{
+    ($map:ident, $func:ident, $reader:ident, $section:ident) => {{
         #[cfg(not(any(feature = "async_std", feature = "async_tokio")))]
-        if $map.$func(&mut $reader, &mut $buf, &mut $section)? {
+        if $map.$func(&mut $reader, &mut $section)? {
             break;
         }
 
         #[cfg(any(feature = "async_std", feature = "async_tokio"))]
-        if $map.$func(&mut $reader, &mut $buf, &mut $section).await? {
+        if $map.$func(&mut $reader, &mut $section).await? {
             break;
         }
     }};
 }
 
-macro_rules! read_line {
-    ($reader:ident, $buf:expr) => {{
+macro_rules! next_line {
+    ($reader:ident) => {{
         #[cfg(any(feature = "async_std", feature = "async_tokio"))]
         {
-            $reader.read_line($buf).await
+            $reader.next_line().await
         }
 
         #[cfg(not(any(feature = "async_std", feature = "async_tokio")))]
         {
-            $reader.read_line($buf)
+            $reader.next_line()
         }
     }};
 }
 
 macro_rules! parse_general_body {
-    ($self:ident, $reader:ident, $buf:ident, $section:ident) => {{
+    ($self:ident, $reader:ident, $section:ident) => {{
         let mut mode = None;
         let mut empty = true;
         let mut stack_leniency = None;
 
-        while read_line!($reader, $buf)? != 0 {
-            let line = line_prepare!($buf);
-
-            if line.starts_with('[') && line.ends_with(']') {
-                *$section = Section::from_str(&line[1..line.len() - 1]);
+        while next_line!($reader)? != 0 {
+            if let Some(bytes) = $reader.get_section() {
+                *$section = Section::from_bytes(bytes);
                 empty = false;
-                $buf.clear();
                 break;
             }
 
-            let (key, value) = split_colon(&line).ok_or(ParseError::BadLine)?;
+            let (key, value) = $reader.split_colon().ok_or(ParseError::BadLine)?;
 
-            if key == "Mode" {
+            if key == b"Mode" {
                 mode = match value {
                     "0" => Some(GameMode::STD),
                     "1" => Some(GameMode::TKO),
@@ -139,11 +119,9 @@ macro_rules! parse_general_body {
                 };
             }
 
-            if key == "StackLeniency" {
+            if key == b"StackLeniency" {
                 stack_leniency = Some(value.parse()?);
             }
-
-            $buf.clear();
         }
 
         $self.mode = mode.unwrap_or(GameMode::STD);
@@ -157,28 +135,26 @@ macro_rules! parse_general {
     () => {
         fn parse_general<R: Read>(
             &mut self,
-            reader: &mut BufReader<R>,
-            buf: &mut String,
+            reader: &mut FileReader<R>,
             section: &mut Section,
         ) -> ParseResult<bool> {
-            parse_general_body!(self, reader, buf, section)
+            parse_general_body!(self, reader, section)
         }
     };
 
     (async $reader:ident<$inner:ident>) => {
         async fn parse_general<R: $inner + Unpin>(
             &mut self,
-            reader: &mut $reader<R>,
-            buf: &mut String,
+            reader: &mut FileReader<R>,
             section: &mut Section,
         ) -> ParseResult<bool> {
-            parse_general_body!(self, reader, buf, section)
+            parse_general_body!(self, reader, section)
         }
     };
 }
 
 macro_rules! parse_difficulty_body {
-    ($self:ident, $reader:ident, $buf:ident, $section:ident) => {{
+    ($self:ident, $reader:ident, $section:ident) => {{
         let mut ar = None;
         let mut od = None;
         let mut cs = None;
@@ -188,29 +164,24 @@ macro_rules! parse_difficulty_body {
 
         let mut empty = true;
 
-        while read_line!($reader, $buf)? != 0 {
-            let line = line_prepare!($buf);
-
-            if line.starts_with('[') && line.ends_with(']') {
-                *$section = Section::from_str(&line[1..line.len() - 1]);
+        while next_line!($reader)? != 0 {
+            if let Some(bytes) = $reader.get_section() {
+                *$section = Section::from_bytes(bytes);
                 empty = false;
-                $buf.clear();
                 break;
             }
 
-            let (key, value) = split_colon(&line).ok_or(ParseError::BadLine)?;
+            let (key, value) = $reader.split_colon().ok_or(ParseError::BadLine)?;
 
             match key {
-                "ApproachRate" => ar = Some(value.parse()?),
-                "OverallDifficulty" => od = Some(value.parse()?),
-                "CircleSize" => cs = Some(value.parse()?),
-                "HPDrainRate" => hp = Some(value.parse()?),
-                "SliderTickRate" => tick_rate = Some(value.parse()?),
-                "SliderMultiplier" => sv = Some(value.parse()?),
+                b"ApproachRate" => ar = Some(value.parse()?),
+                b"OverallDifficulty" => od = Some(value.parse()?),
+                b"CircleSize" => cs = Some(value.parse()?),
+                b"HPDrainRate" => hp = Some(value.parse()?),
+                b"SliderTickRate" => tick_rate = Some(value.parse()?),
+                b"SliderMultiplier" => sv = Some(value.parse()?),
                 _ => {}
             }
-
-            $buf.clear();
         }
 
         const DEFAULT_DIFFICULTY: f32 = 5.0;
@@ -230,28 +201,26 @@ macro_rules! parse_difficulty {
     () => {
         fn parse_difficulty<R: Read>(
             &mut self,
-            reader: &mut BufReader<R>,
-            buf: &mut String,
+            reader: &mut FileReader<R>,
             section: &mut Section,
         ) -> ParseResult<bool> {
-            parse_difficulty_body!(self, reader, buf, section)
+            parse_difficulty_body!(self, reader, section)
         }
     };
 
     (async $reader:ident<$inner:ident>) => {
         async fn parse_difficulty<R: $inner + Unpin>(
             &mut self,
-            reader: &mut $reader<R>,
-            buf: &mut String,
+            reader: &mut FileReader<R>,
             section: &mut Section,
         ) -> ParseResult<bool> {
-            parse_difficulty_body!(self, reader, buf, section)
+            parse_difficulty_body!(self, reader, section)
         }
     };
 }
 
 macro_rules! parse_timingpoints_body {
-    ($self:ident, $reader:ident, $buf:ident, $section:ident) => {{
+    ($self:ident, $reader:ident, $section:ident) => {{
         let mut unsorted_timings = false;
         let mut unsorted_difficulties = false;
 
@@ -260,16 +229,14 @@ macro_rules! parse_timingpoints_body {
 
         let mut empty = true;
 
-        while read_line!($reader, $buf)? != 0 {
-            let line = line_prepare!($buf);
-
-            if line.starts_with('[') && line.ends_with(']') {
-                *$section = Section::from_str(&line[1..line.len() - 1]);
+        while next_line!($reader)? != 0 {
+            if let Some(bytes) = $reader.get_section() {
+                *$section = Section::from_bytes(bytes);
                 empty = false;
-                $buf.clear();
                 break;
             }
 
+            let line = $reader.get_line();
             let mut split = line.split(',');
 
             let time = split
@@ -311,8 +278,6 @@ macro_rules! parse_timingpoints_body {
                     prev_diff = time;
                 }
             }
-
-            $buf.clear();
         }
 
         if unsorted_timings {
@@ -331,28 +296,26 @@ macro_rules! parse_timingpoints {
     () => {
         fn parse_timingpoints<R: Read>(
             &mut self,
-            reader: &mut BufReader<R>,
-            buf: &mut String,
+            reader: &mut FileReader<R>,
             section: &mut Section,
         ) -> ParseResult<bool> {
-            parse_timingpoints_body!(self, reader, buf, section)
+            parse_timingpoints_body!(self, reader, section)
         }
     };
 
     (async $reader:ident<$inner:ident>) => {
         async fn parse_timingpoints<R: $inner + Unpin>(
             &mut self,
-            reader: &mut $reader<R>,
-            buf: &mut String,
+            reader: &mut FileReader<R>,
             section: &mut Section,
         ) -> ParseResult<bool> {
-            parse_timingpoints_body!(self, reader, buf, section)
+            parse_timingpoints_body!(self, reader, section)
         }
     };
 }
 
 macro_rules! parse_hitobjects_body {
-    ($self:ident, $reader:ident, $buf:ident, $section:ident) => {{
+    ($self:ident, $reader:ident, $section:ident) => {{
         let mut unsorted = false;
         let mut prev_time = 0.0;
         let mut empty = true;
@@ -366,16 +329,14 @@ macro_rules! parse_hitobjects_body {
         // Buffer to re-use for all sliders
         let mut vertices = Vec::new();
 
-        while read_line!($reader, $buf)? != 0 {
-            let line = line_prepare!($buf);
-
-            if line.starts_with('[') && line.ends_with(']') {
-                *$section = Section::from_str(&line[1..line.len() - 1]);
+        while next_line!($reader)? != 0 {
+            if let Some(bytes) = $reader.get_section() {
+                *$section = Section::from_bytes(bytes);
                 empty = false;
-                $buf.clear();
                 break;
             }
 
+            let line = $reader.get_line();
             let mut split = line.split(',');
 
             let pos = Pos2 {
@@ -511,7 +472,6 @@ macro_rules! parse_hitobjects_body {
             $self.sounds.push(sound);
 
             prev_time = time;
-            $buf.clear();
         }
 
         // BUG: If [General] section comes after [HitObjects] then the mode
@@ -536,49 +496,35 @@ macro_rules! parse_hitobjects {
     () => {
         fn parse_hitobjects<R: Read>(
             &mut self,
-            reader: &mut BufReader<R>,
-            buf: &mut String,
+            reader: &mut FileReader<R>,
             section: &mut Section,
         ) -> ParseResult<bool> {
-            parse_hitobjects_body!(self, reader, buf, section)
+            parse_hitobjects_body!(self, reader, section)
         }
     };
 
     (async $reader:ident<$inner:ident>) => {
         async fn parse_hitobjects<R: $inner + Unpin>(
             &mut self,
-            reader: &mut $reader<R>,
-            buf: &mut String,
+            reader: &mut FileReader<R>,
             section: &mut Section,
         ) -> ParseResult<bool> {
-            parse_hitobjects_body!(self, reader, buf, section)
+            parse_hitobjects_body!(self, reader, section)
         }
     };
 }
 
 macro_rules! parse_body {
-    ($reader:ident<$inner:ident>: $input:ident) => {{
-        let mut reader = $reader::new($input);
-        let mut buf = String::new();
+    ($input:ident) => {{
+        let mut reader = FileReader::new($input);
 
-        while read_line!(reader, &mut buf)? != 0 {
-            // Check for character U+FEFF specifically thanks to map id 797130
-            if !buf
-                .trim_matches(|c: char| c.is_whitespace() || c == '﻿')
-                .is_empty()
-            {
+        while next_line!(reader)? != 0 {
+            if !reader.is_initial_empty_line() {
                 break;
             }
-
-            buf.clear();
         }
 
-        let version = match buf.find(OSU_FILE_HEADER) {
-            Some(idx) => buf[idx + OSU_FILE_HEADER.len()..].trim_end().parse()?,
-            None => return Err(ParseError::IncorrectFileHeader),
-        };
-
-        buf.clear();
+        let version = reader.version().ok_or(ParseError::IncorrectFileHeader)?;
 
         let mut map = Beatmap {
             version,
@@ -591,22 +537,18 @@ macro_rules! parse_body {
 
         loop {
             match section {
-                Section::General => section!(map, parse_general, reader, buf, section),
-                Section::Difficulty => section!(map, parse_difficulty, reader, buf, section),
-                Section::TimingPoints => section!(map, parse_timingpoints, reader, buf, section),
-                Section::HitObjects => section!(map, parse_hitobjects, reader, buf, section),
+                Section::General => section!(map, parse_general, reader, section),
+                Section::Difficulty => section!(map, parse_difficulty, reader, section),
+                Section::TimingPoints => section!(map, parse_timingpoints, reader, section),
+                Section::HitObjects => section!(map, parse_hitobjects, reader, section),
                 Section::None => {
-                    if read_line!(reader, &mut buf)? == 0 {
+                    if next_line!(reader)? == 0 {
                         break;
                     }
 
-                    let line = line_prepare!(buf);
-
-                    if line.starts_with('[') && line.ends_with(']') {
-                        section = Section::from_str(&line[1..line.len() - 1]);
+                    if let Some(bytes) = reader.get_section() {
+                        section = Section::from_bytes(bytes);
                     }
-
-                    buf.clear();
                 }
             }
         }
@@ -623,7 +565,7 @@ macro_rules! parse {
         /// You'll likely want to pass (a reference of) a [`File`](std::fs::File)
         /// or the file's content as a slice of bytes (`&[u8]`).
         pub fn parse<R: Read>(input: R) -> ParseResult<Self> {
-            parse_body!(BufReader<Read>: input)
+            parse_body!(input)
         }
     };
 
@@ -635,7 +577,7 @@ macro_rules! parse {
         /// You'll likely want to pass a `File`
         /// or the file's content as a slice of bytes (`&[u8]`).
         pub async fn parse<R: $inner + Unpin>(input: R) -> ParseResult<Self> {
-            parse_body!($reader<$inner>: input)
+            parse_body!(input)
         }
     };
 }
@@ -727,8 +669,6 @@ pub struct Beatmap {
     /// the stack offset for stacked positions.
     pub stack_leniency: f32,
 }
-
-pub(crate) const OSU_FILE_HEADER: &str = "osu file format v";
 
 impl Beatmap {
     const CIRCLE_FLAG: u8 = 1 << 0;
@@ -936,16 +876,6 @@ impl Beatmap {
     from_path!(async Path);
 }
 
-fn skip_line(line: &str) -> bool {
-    line.is_empty() || line.starts_with("//") || line.starts_with(' ') || line.starts_with('_')
-}
-
-fn split_colon(line: &str) -> Option<(&str, &str)> {
-    let (front, back) = line.split_once(':')?;
-
-    Some((front, back.trim()))
-}
-
 #[derive(Copy, Clone, Debug)]
 enum Section {
     None,
@@ -956,13 +886,12 @@ enum Section {
 }
 
 impl Section {
-    #[inline]
-    fn from_str(s: &str) -> Self {
-        match s {
-            "General" => Self::General,
-            "Difficulty" => Self::Difficulty,
-            "TimingPoints" => Self::TimingPoints,
-            "HitObjects" => Self::HitObjects,
+    fn from_bytes(bytes: &[u8]) -> Self {
+        match bytes {
+            b"General" => Self::General,
+            b"Difficulty" => Self::Difficulty,
+            b"TimingPoints" => Self::TimingPoints,
+            b"HitObjects" => Self::HitObjects,
             _ => Self::None,
         }
     }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -13,6 +13,9 @@ pub use error::{ParseError, ParseResult};
 pub use hitobject::{HitObject, HitObjectKind};
 pub use hitsound::HitSound;
 pub use pos2::Pos2;
+pub use slider_parsing::*;
+
+use reader::FileReader;
 use sort::legacy_sort;
 
 use std::cmp::Ordering;
@@ -21,24 +24,13 @@ use std::cmp::Ordering;
 use std::{fs::File, io::Read};
 
 #[cfg(feature = "async_tokio")]
-use tokio::{
-    fs::File,
-    io::{AsyncBufReadExt, AsyncRead, BufReader},
-};
+use tokio::{fs::File, io::AsyncRead};
 
 #[cfg(not(feature = "async_std"))]
 use std::path::Path;
 
 #[cfg(feature = "async_std")]
-use async_std::{
-    fs::File,
-    io::{prelude::BufReadExt, BufReader as AsyncBufReader, Read as AsyncRead},
-    path::Path,
-};
-
-pub use slider_parsing::*;
-
-use reader::FileReader;
+use async_std::{fs::File, io::Read as AsyncRead, path::Path};
 
 fn sort_unstable<T: PartialOrd>(slice: &mut [T]) {
     slice.sort_unstable_by(|p1, p2| p1.partial_cmp(p2).unwrap_or(Ordering::Equal));

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -228,7 +228,7 @@ macro_rules! parse_timingpoints_body {
                 break;
             }
 
-            let line = $reader.get_line().ok_or(ParseError::InvalidUtf8)?;
+            let line = $reader.get_line()?;
             let mut split = line.split(',');
 
             let time = split
@@ -328,7 +328,7 @@ macro_rules! parse_hitobjects_body {
                 break;
             }
 
-            let line = $reader.get_line().ok_or(ParseError::InvalidUtf8)?;
+            let line = $reader.get_line()?;
             let mut split = line.split(',');
 
             let pos = Pos2 {
@@ -515,10 +515,8 @@ macro_rules! parse_body {
             next_line!(reader)?;
         }
 
-        let version = reader.version().ok_or(ParseError::IncorrectFileHeader)?;
-
         let mut map = Beatmap {
-            version,
+            version: reader.version()?,
             hit_objects: Vec::with_capacity(256),
             sounds: Vec::with_capacity(256),
             ..Default::default()

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -134,8 +134,8 @@ macro_rules! parse_general {
         }
     };
 
-    (async $reader:ident<$inner:ident>) => {
-        async fn parse_general<R: $inner + Unpin>(
+    (async) => {
+        async fn parse_general<R: AsyncRead + Unpin>(
             &mut self,
             reader: &mut FileReader<R>,
             section: &mut Section,
@@ -200,8 +200,8 @@ macro_rules! parse_difficulty {
         }
     };
 
-    (async $reader:ident<$inner:ident>) => {
-        async fn parse_difficulty<R: $inner + Unpin>(
+    (async) => {
+        async fn parse_difficulty<R: AsyncRead + Unpin>(
             &mut self,
             reader: &mut FileReader<R>,
             section: &mut Section,
@@ -295,8 +295,8 @@ macro_rules! parse_timingpoints {
         }
     };
 
-    (async $reader:ident<$inner:ident>) => {
-        async fn parse_timingpoints<R: $inner + Unpin>(
+    (async) => {
+        async fn parse_timingpoints<R: AsyncRead + Unpin>(
             &mut self,
             reader: &mut FileReader<R>,
             section: &mut Section,
@@ -495,8 +495,8 @@ macro_rules! parse_hitobjects {
         }
     };
 
-    (async $reader:ident<$inner:ident>) => {
-        async fn parse_hitobjects<R: $inner + Unpin>(
+    (async) => {
+        async fn parse_hitobjects<R: AsyncRead + Unpin>(
             &mut self,
             reader: &mut FileReader<R>,
             section: &mut Section,
@@ -558,14 +558,14 @@ macro_rules! parse {
         }
     };
 
-    (async $reader:ident<$inner:ident>) => {
+    (async) => {
         /// Parse a beatmap from a `.osu` file.
         ///
         /// As argument you can give anything that implements `tokio::io::AsyncRead`
         /// or `async_std::io::Read`, depending which feature you chose.
         /// You'll likely want to pass a `File`
         /// or the file's content as a slice of bytes (`&[u8]`).
-        pub async fn parse<R: $inner + Unpin>(input: R) -> ParseResult<Self> {
+        pub async fn parse<R: AsyncRead + Unpin>(input: R) -> ParseResult<Self> {
             parse_body!(input)
         }
     };
@@ -583,11 +583,11 @@ macro_rules! from_path {
         }
     };
 
-    (async $path:ident) => {
+    (async) => {
         /// Pass the path to a `.osu` file.
         ///
         /// Useful when you don't want to create the file manually.
-        pub async fn from_path<P: AsRef<$path>>(path: P) -> ParseResult<Self> {
+        pub async fn from_path<P: AsRef<Path>>(path: P) -> ParseResult<Self> {
             Self::parse(File::open(path).await?).await
         }
     };
@@ -845,24 +845,24 @@ impl Beatmap {
 
 #[cfg(feature = "async_tokio")]
 impl Beatmap {
-    parse!(async BufReader<AsyncRead>);
-    parse_general!(async BufReader<AsyncRead>);
-    parse_difficulty!(async BufReader<AsyncRead>);
-    parse_timingpoints!(async BufReader<AsyncRead>);
-    parse_hitobjects!(async BufReader<AsyncRead>);
+    parse!(async);
+    parse_general!(async);
+    parse_difficulty!(async);
+    parse_timingpoints!(async);
+    parse_hitobjects!(async);
 
-    from_path!(async Path);
+    from_path!(async);
 }
 
 #[cfg(feature = "async_std")]
 impl Beatmap {
-    parse!(async AsyncBufReader<AsyncRead>);
-    parse_general!(async AsyncBufReader<AsyncRead>);
-    parse_difficulty!(async AsyncBufReader<AsyncRead>);
-    parse_timingpoints!(async AsyncBufReader<AsyncRead>);
-    parse_hitobjects!(async AsyncBufReader<AsyncRead>);
+    parse!(async);
+    parse_general!(async);
+    parse_difficulty!(async);
+    parse_timingpoints!(async);
+    parse_hitobjects!(async);
 
-    from_path!(async Path);
+    from_path!(async);
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -228,7 +228,7 @@ macro_rules! parse_timingpoints_body {
                 break;
             }
 
-            let line = $reader.get_line();
+            let line = $reader.get_line().ok_or(ParseError::InvalidUtf8)?;
             let mut split = line.split(',');
 
             let time = split
@@ -328,7 +328,7 @@ macro_rules! parse_hitobjects_body {
                 break;
             }
 
-            let line = $reader.get_line();
+            let line = $reader.get_line().ok_or(ParseError::InvalidUtf8)?;
             let mut split = line.split(',');
 
             let pos = Pos2 {
@@ -509,11 +509,10 @@ macro_rules! parse_hitobjects {
 macro_rules! parse_body {
     ($input:ident) => {{
         let mut reader = FileReader::new($input);
+        next_line!(reader)?;
 
-        while next_line!(reader)? != 0 {
-            if !reader.is_initial_empty_line() {
-                break;
-            }
+        if reader.is_initial_empty_line() {
+            next_line!(reader)?;
         }
 
         let version = reader.version().ok_or(ParseError::IncorrectFileHeader)?;

--- a/src/parse/reader.rs
+++ b/src/parse/reader.rs
@@ -131,21 +131,27 @@ impl<R> FileReader<R> {
     }
 
     pub(crate) fn version(&self) -> Option<u8> {
-        if self.buf.starts_with(b"osu file format v") {
-            let mut n = 0;
+        self.buf
+            .iter()
+            .position(|&byte| byte == b'o')
+            .and_then(|idx| {
+                self.buf[idx..]
+                    .starts_with(b"osu file format v")
+                    .then(|| idx + 17)
+            })
+            .map(|idx| {
+                let mut n = 0;
 
-            for byte in &self.buf[17..] {
-                if !(b'0'..=b'9').contains(byte) {
-                    break;
+                for byte in &self.buf[idx..] {
+                    if !(b'0'..=b'9').contains(byte) {
+                        break;
+                    }
+
+                    n = 10 * n + (*byte & 0xF);
                 }
 
-                n = 10 * n + (*byte & 0xF);
-            }
-
-            Some(n)
-        } else {
-            None
-        }
+                n
+            })
     }
 
     /// Returns the bytes inbetween '[' and ']'.

--- a/src/parse/reader.rs
+++ b/src/parse/reader.rs
@@ -1,0 +1,157 @@
+#[cfg(not(any(feature = "async_std", feature = "async_tokio")))]
+use std::io::{BufRead, BufReader, Error as IoError, Read};
+
+pub(crate) struct FileReader<R> {
+    #[cfg(feature = "async_std")] // TODO
+    inner: BufReader<R>,
+    #[cfg(feature = "async_tokio")] // TODO
+    inner: BufReader<R>,
+    #[cfg(not(any(feature = "async_std", feature = "async_tokio")))]
+    inner: BufReader<R>,
+
+    buf: Vec<u8>,
+}
+
+#[cfg(not(any(feature = "async_std", feature = "async_tokio")))]
+impl<R: Read> FileReader<R> {
+    pub(crate) fn new(src: R) -> Self {
+        Self {
+            inner: BufReader::new(src),
+            buf: Vec::with_capacity(32),
+        }
+    }
+
+    pub(crate) fn next_line(&mut self) -> Result<usize, IoError> {
+        loop {
+            self.buf.clear();
+            let bytes = self.inner.read_until(b'\n', &mut self.buf)?;
+
+            // TODO: check on lines like `       // comment continuation`
+            if !skip_line(&self.buf) {
+                return Ok(bytes);
+            }
+        }
+    }
+}
+
+impl<R> FileReader<R> {
+    pub(crate) fn is_initial_empty_line(&self) -> bool {
+        let pats: [&[u8]; 5] = [
+            &[b' '],
+            &[b'\t'],
+            &[b'\n'],
+            &[b'\r'],
+            &[239, 187, 191], // U+FEFF
+        ];
+
+        consists_of(&self.buf, pats)
+    }
+
+    pub(crate) fn version(&self) -> Option<u8> {
+        const OSU_FILE_HEADER: &[u8] = b"osu file format v";
+
+        self.find(OSU_FILE_HEADER)
+            .and_then(|i| self.buf.get(i + OSU_FILE_HEADER.len()..))
+            .map(|infix| {
+                let mut n = 0;
+
+                for byte in infix {
+                    if !(b'0'..=b'9').contains(byte) {
+                        break;
+                    }
+
+                    n = 10 * n + (*byte & 0xF);
+                }
+
+                n
+            })
+    }
+
+    pub(crate) fn get_section(&self) -> Option<&[u8]> {
+        if self.buf[0] == b'[' {
+            if let Some(end) = self.find(&[b']']) {
+                return Some(&self.buf[1..end]);
+            }
+        }
+
+        None
+    }
+
+    pub(crate) fn get_line(&self) -> &str {
+        // TODO: benchmark if necessary
+        // trim comment so the utf8 validation skips it
+        let end = self
+            .buf
+            .windows(3)
+            .rev()
+            .step_by(2)
+            .zip(1..)
+            .find_map(|(window, i)| {
+                if window[1] == b'/' {
+                    if window[0] == b'/' {
+                        return Some(self.buf.len() - 2 * i - 1);
+                    } else if window[2] == b'/' {
+                        return Some(self.buf.len() - 2 * i);
+                    }
+                }
+
+                None
+            })
+            .unwrap_or(self.buf.len());
+
+        std::str::from_utf8(&self.buf[..end]).unwrap().trim_end()
+    }
+
+    pub(crate) fn split_colon(&self) -> Option<(&[u8], &str)> {
+        let idx = self.buf.iter().position(|&byte| byte == b':')?;
+        let front = &self.buf[..idx];
+        let back = std::str::from_utf8(&self.buf[idx + 1..]).ok()?;
+
+        Some((front, back.trim()))
+    }
+
+    fn find(&self, pat: &[u8]) -> Option<usize> {
+        self.buf
+            .windows(pat.len())
+            .enumerate()
+            .find_map(|(i, window)| (window == pat).then(|| i))
+    }
+}
+
+fn skip_line(line: &[u8]) -> bool {
+    !line.is_empty()
+        && (matches!(line[0], b'\n' | b' ' | b'_') || (line.len() >= 2 && &line[..2] == b"//"))
+}
+
+/// Check if `src` is a combination of the given patterns.
+fn consists_of<const N: usize>(src: &[u8], pats: [&[u8]; N]) -> bool {
+    let max_len = pats.iter().map(|pat| pat.len()).max().unwrap_or(0);
+    let limit = src.len().saturating_sub(max_len);
+    let mut i = 0;
+
+    'outer1: while i < limit {
+        for pat in pats {
+            if &src[i..i + pat.len()] == pat {
+                i += pat.len();
+
+                continue 'outer1;
+            }
+        }
+
+        return false;
+    }
+
+    'outer2: while i < src.len() {
+        for pat in pats {
+            if i + pat.len() <= src.len() && &src[i..i + pat.len()] == pat {
+                i += pat.len();
+
+                continue 'outer2;
+            }
+        }
+
+        return false;
+    }
+
+    true
+}


### PR DESCRIPTION
Now loading the input bytes into a raw `Vec<u8>` instead of a `String` and only perform the UTF-8 validation for the necessary sections.
Improves parsing performance by ~13% and fixes #8 i.e. parsing UTF-16 and ANSI encoded files.
All ~130k ranked maps are now parsed without error'ing or panicking.