### PR TITLE
reworked attribute calculation

### DIFF
--- a/src/beatmap/mod.rs
+++ b/src/beatmap/mod.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, cmp::Ordering};
 use crate::parse::HitObject;
 
 pub use self::{
-    attributes::BeatmapAttributes,
+    attributes::{BeatmapAttributes, BeatmapAttributesBuilder, BeatmapHitWindows},
     breaks::Break,
     control_points::{ControlPoint, ControlPointIter, DifficultyPoint, TimingPoint},
     mode::GameMode,
@@ -66,8 +66,8 @@ pub struct Beatmap {
 impl Beatmap {
     /// Extract a beatmap's attributes into their own type.
     #[inline]
-    pub fn attributes(&self) -> BeatmapAttributes {
-        BeatmapAttributes::new(self.ar, self.od, self.cs, self.hp)
+    pub fn attributes(&self) -> BeatmapAttributesBuilder {
+        BeatmapAttributesBuilder::new(self)
     }
 
     /// The beats per minute of the map.

--- a/src/catch/gradual_difficulty.rs
+++ b/src/catch/gradual_difficulty.rs
@@ -66,8 +66,8 @@ pub struct CatchGradualDifficultyAttributes<'map> {
 
 impl<'map> CatchGradualDifficultyAttributes<'map> {
     /// Create a new difficulty attributes iterator for osu!catch maps.
-    pub fn new(map: &'map Beatmap, mods: impl Mods) -> Self {
-        let map_attributes = map.attributes().mods(mods);
+    pub fn new(map: &'map Beatmap, mods: u32) -> Self {
+        let map_attributes = map.attributes().mods(mods).build();
 
         let attributes = CatchDifficultyAttributes {
             ar: map_attributes.ar,

--- a/src/catch/mod.rs
+++ b/src/catch/mod.rs
@@ -146,8 +146,8 @@ fn calculate_movement(params: CatchStars<'_>) -> (Movement, CatchDifficultyAttri
     } = params;
 
     let take = passed_objects.unwrap_or(usize::MAX);
-    let map_attributes = map.attributes().mods(mods);
-    let clock_rate = clock_rate.unwrap_or(map_attributes.clock_rate);
+    let clock_rate = clock_rate.unwrap_or_else(|| mods.clock_rate());
+    let map_attributes = map.attributes().mods(mods).clock_rate(clock_rate).build();
 
     let attributes = CatchDifficultyAttributes {
         ar: map_attributes.ar,

--- a/src/gradual.rs
+++ b/src/gradual.rs
@@ -3,7 +3,7 @@ use crate::{
     mania::{ManiaGradualDifficultyAttributes, ManiaGradualPerformanceAttributes},
     osu::{OsuGradualDifficultyAttributes, OsuGradualPerformanceAttributes, OsuScoreState},
     taiko::{TaikoGradualDifficultyAttributes, TaikoGradualPerformanceAttributes, TaikoScoreState},
-    Beatmap, DifficultyAttributes, GameMode, Mods, PerformanceAttributes,
+    Beatmap, DifficultyAttributes, GameMode, PerformanceAttributes,
 };
 
 /// Gradually calculate the difficulty attributes on maps of any mode.
@@ -51,7 +51,7 @@ pub enum GradualDifficultyAttributes<'map> {
 
 impl<'map> GradualDifficultyAttributes<'map> {
     /// Create a new gradual difficulty calculator for maps of any mode.
-    pub fn new(map: &'map Beatmap, mods: impl Mods) -> Self {
+    pub fn new(map: &'map Beatmap, mods: u32) -> Self {
         match map.mode {
             GameMode::Osu => Self::Osu(OsuGradualDifficultyAttributes::new(map, mods)),
             GameMode::Taiko => Self::Taiko(TaikoGradualDifficultyAttributes::new(map, mods)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,7 @@ pub trait BeatmapExt {
     /// Return an iterator that gives you the [`DifficultyAttributes`] after each hit object.
     ///
     /// Suitable to efficiently get the map's star rating after multiple different locations.
-    fn gradual_difficulty(&self, mods: impl Mods) -> GradualDifficultyAttributes<'_>;
+    fn gradual_difficulty(&self, mods: u32) -> GradualDifficultyAttributes<'_>;
 
     /// Return a struct that gives you the [`PerformanceAttributes`] after every (few) hit object(s).
     ///
@@ -294,7 +294,7 @@ impl BeatmapExt for Beatmap {
     }
 
     #[inline]
-    fn gradual_difficulty(&self, mods: impl Mods) -> GradualDifficultyAttributes<'_> {
+    fn gradual_difficulty(&self, mods: u32) -> GradualDifficultyAttributes<'_> {
         GradualDifficultyAttributes::new(self, mods)
     }
 
@@ -507,17 +507,6 @@ impl From<taiko::TaikoPerformanceAttributes> for PerformanceAttributes {
     #[inline]
     fn from(attributes: taiko::TaikoPerformanceAttributes) -> Self {
         Self::Taiko(attributes)
-    }
-}
-
-#[inline]
-fn difficulty_range(val: f64, max: f64, avg: f64, min: f64) -> f64 {
-    if val > 5.0 {
-        avg + (max - avg) * (val - 5.0) / 5.0
-    } else if val < 5.0 {
-        avg - (avg - min) * (5.0 - val) / 5.0
-    } else {
-        avg
     }
 }
 

--- a/src/osu/gradual_difficulty.rs
+++ b/src/osu/gradual_difficulty.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use super::{
-    calculate_star_rating, difficulty_range_ar, difficulty_range_od, old_stacking,
+    calculate_star_rating, old_stacking,
     osu_object::{ObjectParameters, OsuObject, OsuObjectKind},
     scaling_factor::ScalingFactor,
     skill::{Skill, Skills},
@@ -58,27 +58,17 @@ pub struct OsuGradualDifficultyAttributes {
 
 impl OsuGradualDifficultyAttributes {
     /// Create a new difficulty attributes iterator for osu!standard maps.
-    pub fn new(map: &Beatmap, mods: impl Mods) -> Self {
-        let map_attributes = map.attributes().mods(mods);
-        let hit_window = difficulty_range_od(map_attributes.od) / map_attributes.clock_rate;
-        let od = (80.0 - hit_window) / 6.0;
-
-        let mut raw_ar = map.ar as f64;
+    pub fn new(map: &Beatmap, mods: u32) -> Self {
+        let map_attributes = map.attributes().mods(mods).build();
+        let hit_window = map_attributes.hit_windows.od;
+        let time_preempt = map_attributes.hit_windows.ar;
         let hr = mods.hr();
-
-        if hr {
-            raw_ar = (raw_ar * 1.4).min(10.0);
-        } else if mods.ez() {
-            raw_ar *= 0.5;
-        }
-
-        let time_preempt = difficulty_range_ar(raw_ar);
         let scaling_factor = ScalingFactor::new(map_attributes.cs);
 
         let mut attributes = OsuDifficultyAttributes {
             ar: map_attributes.ar,
             hp: map_attributes.hp,
-            od,
+            od: map_attributes.od,
             ..Default::default()
         };
 

--- a/src/osu/mod.rs
+++ b/src/osu/mod.rs
@@ -264,26 +264,16 @@ fn calculate_skills(params: OsuStars<'_>) -> (Skills, OsuDifficultyAttributes) {
     let take = passed_objects.unwrap_or(map.hit_objects.len());
     let clock_rate = clock_rate.unwrap_or_else(|| mods.clock_rate());
 
-    let map_attributes = map.attributes().mods(mods);
-    let hit_window = difficulty_range_od(map_attributes.od) / clock_rate;
-    let od = (80.0 - hit_window) / 6.0;
-
-    let mut raw_ar = map.ar as f64;
-    let hr = mods.hr();
-
-    if hr {
-        raw_ar = (raw_ar * 1.4).min(10.0);
-    } else if mods.ez() {
-        raw_ar *= 0.5;
-    }
-
-    let time_preempt = difficulty_range_ar(raw_ar);
+    let map_attributes = map.attributes().mods(mods).clock_rate(clock_rate).build();
     let scaling_factor = ScalingFactor::new(map_attributes.cs);
+    let hr = mods.hr();
+    let time_preempt = map_attributes.hit_windows.ar;
+    let hit_window = map_attributes.hit_windows.od;
 
     let mut attributes = OsuDifficultyAttributes {
         ar: map_attributes.ar,
         hp: map_attributes.hp,
-        od,
+        od: map_attributes.od,
         ..Default::default()
     };
 
@@ -520,11 +510,6 @@ fn old_stacking(hit_objects: &mut [OsuObject], stack_threshold: f64) {
     }
 }
 
-#[inline]
-fn difficulty_range_ar(ar: f64) -> f64 {
-    crate::difficulty_range(ar, 450.0, 1200.0, 1800.0)
-}
-
 fn lerp(start: f64, end: f64, percent: f64) -> f64 {
     start + (end - start) * percent
 }
@@ -608,9 +593,4 @@ impl From<OsuPerformanceAttributes> for OsuDifficultyAttributes {
     fn from(attributes: OsuPerformanceAttributes) -> Self {
         attributes.difficulty
     }
-}
-
-#[inline]
-fn difficulty_range_od(od: f64) -> f64 {
-    super::difficulty_range(od, 20.0, 50.0, 80.0)
 }

--- a/src/taiko/pp.rs
+++ b/src/taiko/pp.rs
@@ -1,7 +1,10 @@
 use std::borrow::Cow;
 
 use super::{TaikoDifficultyAttributes, TaikoPerformanceAttributes, TaikoScoreState, TaikoStars};
-use crate::{Beatmap, DifficultyAttributes, GameMode, Mods, OsuPP, PerformanceAttributes};
+use crate::{
+    beatmap::BeatmapHitWindows, Beatmap, DifficultyAttributes, GameMode, Mods, OsuPP,
+    PerformanceAttributes,
+};
 
 /// Performance calculator on osu!taiko maps.
 ///
@@ -281,15 +284,13 @@ impl<'map> TaikoPPInner<'map> {
 
     #[inline]
     fn compute_accuracy_value(&self) -> f64 {
-        let mut od = self.map.od as f64;
+        let BeatmapHitWindows { od: hit_window, .. } = self
+            .map
+            .attributes()
+            .mods(self.mods)
+            .clock_rate(self.clock_rate)
+            .hit_windows();
 
-        if self.mods.hr() {
-            od *= 1.4;
-        } else if self.mods.ez() {
-            od *= 0.5;
-        }
-
-        let hit_window = difficulty_range_od(od).floor() / self.clock_rate;
         let max_combo = self.attributes.max_combo;
 
         (150.0 / hit_window).powf(1.1)
@@ -297,11 +298,6 @@ impl<'map> TaikoPPInner<'map> {
             * 22.0
             * (max_combo as f64 / 1500.0).powf(0.3).min(1.15)
     }
-}
-
-#[inline]
-fn difficulty_range_od(od: f64) -> f64 {
-    crate::difficulty_range(od, 20.0, 35.0, 50.0)
 }
 
 impl<'map> From<OsuPP<'map>> for TaikoPP<'map> {


### PR DESCRIPTION
Instead of creating `BeatmapAttributes` directly, create a `BeatmapAttributesBuilder` that finalizes into the actual attributes.
This is used for internal calculations but it's also publicly exposed so users can use it too for arbitrary initial attributes, mods, modes, and clock rates.