### PR TITLE
expose BeatmapExt methods for mode-specific objects

### DIFF
--- a/src/beatmap/ext.rs
+++ b/src/beatmap/ext.rs
@@ -46,13 +46,27 @@ pub trait BeatmapExt {
     /// i.e. live update a score's pp.
     fn gradual_performance(&self, mods: u32) -> GradualPerformanceAttributes<'_>;
 
-    /// TODO: docs
+    /// Process each [`HitObject`](crate::parse::HitObject) into a an osu!-specific [`OsuObject`],
+    /// just like the difficulty calculation does.
     fn osu_hitobjects(&self, mods: u32) -> Vec<OsuObject>;
 
-    /// TODO: docs
+    /// Process each [`HitObject`](crate::parse::HitObject) into a an osu!taiko-specific [`TaikoObject`],
+    /// just like the difficulty calculation does.
+    ///
+    /// Only hitcircles produce a [`TaikoObject`] and clockrate is *not* considered.
     fn taiko_hitobjects(&self) -> Vec<TaikoObject>;
 
-    /// TODO: docs
+    /// Process each [`HitObject`](crate::parse::HitObject) into a an osu!ctb-specific [`CatchObject`],
+    /// just like the difficulty calculation does.
+    ///
+    /// A [`CatchObject`] is either a fruit or a droplet which means
+    /// tiny droplets and bananas are not included.
+    fn catch_hitobjects(&self, mods: u32) -> Vec<CatchObject>;
+
+    /// Process each [`HitObject`](crate::parse::HitObject) into a an osu!mania-specific [`ManiaObject`],
+    /// just like the difficulty calculation does.
+    ///
+    /// Clockrate is *not* considered.
     fn mania_hitobjects(&self) -> Vec<ManiaObject>;
 }
 
@@ -165,10 +179,7 @@ impl BeatmapExt for Beatmap {
         for i in 1..hit_objects.len() {
             // SAFETY: The indices are guaranteed the be included based on the loop condition
             let window = unsafe { hit_objects.get_unchecked_mut(i - 1..=i) };
-
-            let [curr, next] = window else {
-                unreachable!();
-            };
+            let [curr, next] = window else { unreachable!() };
 
             curr.init_hyper_dash(
                 half_catcher_width,

--- a/src/beatmap/ext.rs
+++ b/src/beatmap/ext.rs
@@ -53,7 +53,7 @@ pub trait BeatmapExt {
     /// Process each [`HitObject`](crate::parse::HitObject) into a an osu!taiko-specific [`TaikoObject`],
     /// just like the difficulty calculation does.
     ///
-    /// Only hitcircles produce a [`TaikoObject`] and clockrate is *not* considered.
+    /// Clockrate is *not* considered.
     fn taiko_hitobjects(&self) -> Vec<TaikoObject>;
 
     /// Process each [`HitObject`](crate::parse::HitObject) into a an osu!ctb-specific [`CatchObject`],

--- a/src/beatmap/ext.rs
+++ b/src/beatmap/ext.rs
@@ -1,5 +1,7 @@
 use crate::{
+    mania::{ManiaObject, ObjectParameters},
     osu::{OsuDifficultyAttributes, OsuObject, ScalingFactor},
+    util::FloatExt,
     AnyPP, AnyStars, Beatmap, CatchPP, CatchStars, GameMode, GradualDifficultyAttributes,
     GradualPerformanceAttributes, ManiaPP, ManiaStars, Mods, OsuPP, OsuStars,
     PerformanceAttributes, Strains, TaikoPP, TaikoStars,
@@ -40,6 +42,9 @@ pub trait BeatmapExt {
 
     /// TODO: docs
     fn osu_hitobjects(&self, mods: u32) -> Vec<OsuObject>;
+
+    /// TODO: docs
+    fn mania_hitobjects(&self) -> Vec<ManiaObject>;
 }
 
 impl BeatmapExt for Beatmap {
@@ -109,5 +114,16 @@ impl BeatmapExt for Beatmap {
             hr,
             time_preempt,
         )
+    }
+
+    fn mania_hitobjects(&self) -> Vec<ManiaObject> {
+        let map = self.convert_mode(GameMode::Mania);
+        let total_columns = map.cs.round_even().max(1.0);
+        let mut params = ObjectParameters::new(map.as_ref());
+
+        self.hit_objects
+            .iter()
+            .map(|h| ManiaObject::new(h, total_columns, &mut params))
+            .collect()
     }
 }

--- a/src/beatmap/ext.rs
+++ b/src/beatmap/ext.rs
@@ -1,7 +1,8 @@
 use crate::{
+    osu::{OsuDifficultyAttributes, OsuObject, ScalingFactor},
     AnyPP, AnyStars, Beatmap, CatchPP, CatchStars, GameMode, GradualDifficultyAttributes,
-    GradualPerformanceAttributes, ManiaPP, ManiaStars, OsuPP, OsuStars, PerformanceAttributes,
-    Strains, TaikoPP, TaikoStars,
+    GradualPerformanceAttributes, ManiaPP, ManiaStars, Mods, OsuPP, OsuStars,
+    PerformanceAttributes, Strains, TaikoPP, TaikoStars,
 };
 
 /// Provides some additional methods on [`Beatmap`].
@@ -36,6 +37,9 @@ pub trait BeatmapExt {
     /// Suitable to efficiently get a score's performance after multiple different locations,
     /// i.e. live update a score's pp.
     fn gradual_performance(&self, mods: u32) -> GradualPerformanceAttributes<'_>;
+
+    /// TODO: docs
+    fn osu_hitobjects(&self, mods: u32) -> Vec<OsuObject>;
 }
 
 impl BeatmapExt for Beatmap {
@@ -88,5 +92,22 @@ impl BeatmapExt for Beatmap {
     #[inline]
     fn gradual_performance(&self, mods: u32) -> GradualPerformanceAttributes<'_> {
         GradualPerformanceAttributes::new(self, mods)
+    }
+
+    fn osu_hitobjects(&self, mods: u32) -> Vec<OsuObject> {
+        let attrs = self.attributes().mods(mods).build();
+        let scaling_factor = ScalingFactor::new(attrs.cs);
+        let hr = mods.hr();
+        let time_preempt = (attrs.hit_windows.ar * attrs.clock_rate) as f32 as f64;
+        let mut attrs = OsuDifficultyAttributes::default();
+
+        crate::osu::create_osu_objects(
+            self,
+            &mut attrs,
+            &scaling_factor,
+            usize::MAX,
+            hr,
+            time_preempt,
+        )
     }
 }

--- a/src/beatmap/ext.rs
+++ b/src/beatmap/ext.rs
@@ -26,7 +26,7 @@ pub trait BeatmapExt {
     /// Suitable to plot the difficulty of a map over time.
     fn strains(&self, mods: u32) -> Strains;
 
-    /// Return an iterator that gives you the [`DifficultyAttributes`] after each hit object.
+    /// Return an iterator that gives you the [`DifficultyAttributes`](crate::DifficultyAttributes) after each hit object.
     ///
     /// Suitable to efficiently get the map's star rating after multiple different locations.
     fn gradual_difficulty(&self, mods: u32) -> GradualDifficultyAttributes<'_>;

--- a/src/beatmap/ext.rs
+++ b/src/beatmap/ext.rs
@@ -1,6 +1,7 @@
 use crate::{
     mania::{ManiaObject, ObjectParameters},
     osu::{OsuDifficultyAttributes, OsuObject, ScalingFactor},
+    taiko::{IntoTaikoObjectIter, TaikoObject},
     util::FloatExt,
     AnyPP, AnyStars, Beatmap, CatchPP, CatchStars, GameMode, GradualDifficultyAttributes,
     GradualPerformanceAttributes, ManiaPP, ManiaStars, Mods, OsuPP, OsuStars,
@@ -42,6 +43,9 @@ pub trait BeatmapExt {
 
     /// TODO: docs
     fn osu_hitobjects(&self, mods: u32) -> Vec<OsuObject>;
+
+    /// TODO: docs
+    fn taiko_hitobjects(&self) -> Vec<TaikoObject>;
 
     /// TODO: docs
     fn mania_hitobjects(&self) -> Vec<ManiaObject>;
@@ -114,6 +118,18 @@ impl BeatmapExt for Beatmap {
             hr,
             time_preempt,
         )
+    }
+
+    fn taiko_hitobjects(&self) -> Vec<TaikoObject> {
+        let map = self.convert_mode(GameMode::Taiko);
+
+        map.taiko_objects()
+            .map(|(h, start_time)| TaikoObject {
+                start_time,
+                is_hit: h.is_hit,
+                is_rim: h.is_rim,
+            })
+            .collect()
     }
 
     fn mania_hitobjects(&self) -> Vec<ManiaObject> {

--- a/src/catch/catch_object.rs
+++ b/src/catch/catch_object.rs
@@ -5,7 +5,7 @@ use super::fruit_or_juice::FruitParams;
 const PLAYFIELD_WIDTH: f32 = 512.0;
 const BASE_SPEED: f64 = 1.0;
 
-/// A [`HitObject`] that was processed for the osu!ctb gamemode.
+/// A [`HitObject`](crate::parse::HitObject) that was processed for the osu!ctb gamemode.
 #[derive(Clone, Debug, PartialEq)]
 pub struct CatchObject {
     /// The X position of the object.

--- a/src/catch/catch_object.rs
+++ b/src/catch/catch_object.rs
@@ -5,13 +5,17 @@ use super::fruit_or_juice::FruitParams;
 const PLAYFIELD_WIDTH: f32 = 512.0;
 const BASE_SPEED: f64 = 1.0;
 
-#[derive(Clone, Debug)]
+/// A [`HitObject`] that was processed for the osu!ctb gamemode.
+#[derive(Clone, Debug, PartialEq)]
 pub struct CatchObject {
-    pub(crate) pos: f32,
-    pub(crate) time: f64,
-
-    pub(crate) hyper_dash: bool,
-    pub(crate) hyper_dist: f32,
+    /// The X position of the object.
+    pub pos: f32,
+    /// The time of the object.
+    pub time: f64,
+    /// Whether the object is a hyper dash.
+    pub hyper_dash: bool,
+    /// The hyper distance to the next object
+    pub hyper_dist: f32,
 }
 
 impl CatchObject {

--- a/src/catch/mod.rs
+++ b/src/catch/mod.rs
@@ -6,20 +6,19 @@ mod gradual_performance;
 mod movement;
 mod pp;
 
-use catch_object::CatchObject;
 use difficulty_object::DifficultyObject;
-use fruit_or_juice::FruitOrJuice;
-pub use gradual_difficulty::*;
-pub use gradual_performance::*;
 use movement::Movement;
-pub use pp::*;
 
-use crate::{catch::fruit_or_juice::FruitParams, curve::CurveBuffers, Beatmap, Mods, OsuStars};
+pub use self::{catch_object::CatchObject, gradual_difficulty::*, gradual_performance::*, pp::*};
+
+pub(crate) use self::fruit_or_juice::{FruitOrJuice, FruitParams};
+
+use crate::{curve::CurveBuffers, Beatmap, Mods, OsuStars};
 
 const SECTION_LENGTH: f64 = 750.0;
 const STAR_SCALING_FACTOR: f64 = 0.153;
 
-const ALLOWED_CATCH_RANGE: f32 = 0.8;
+pub(crate) const ALLOWED_CATCH_RANGE: f32 = 0.8;
 const CATCHER_SIZE: f32 = 106.75;
 
 /// Difficulty calculator on osu!catch maps.

--- a/src/mania/mania_object.rs
+++ b/src/mania/mania_object.rs
@@ -22,10 +22,15 @@ impl<'a> ObjectParameters<'a> {
     }
 }
 
-pub(crate) struct ManiaObject {
-    pub(crate) start_time: f64,
-    pub(crate) end_time: f64,
-    pub(crate) column: usize,
+/// A [`HitObject`] that was processed for the osu!mania gamemode.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ManiaObject {
+    /// Start time of the object.
+    pub start_time: f64,
+    /// Endtime of the object.
+    pub end_time: f64,
+    /// Column of the object.
+    pub column: usize,
 }
 
 impl ManiaObject {

--- a/src/mania/mod.rs
+++ b/src/mania/mod.rs
@@ -11,11 +11,10 @@ use crate::{beatmap::BeatmapHitWindows, util::FloatExt, Beatmap, GameMode, Mods,
 
 pub use self::{gradual_difficulty::*, gradual_performance::*, pp::*};
 
-pub(crate) use self::mania_object::ManiaObject;
+pub(crate) use self::mania_object::{ManiaObject, ObjectParameters};
 
 use self::{
     difficulty_object::ManiaDifficultyObject,
-    mania_object::ObjectParameters,
     skills::{Skill, Strain},
 };
 

--- a/src/mania/mod.rs
+++ b/src/mania/mod.rs
@@ -9,9 +9,9 @@ use std::borrow::Cow;
 
 use crate::{beatmap::BeatmapHitWindows, util::FloatExt, Beatmap, GameMode, Mods, OsuStars};
 
-pub use self::{gradual_difficulty::*, gradual_performance::*, pp::*};
+pub use self::{gradual_difficulty::*, gradual_performance::*, mania_object::ManiaObject, pp::*};
 
-pub(crate) use self::mania_object::{ManiaObject, ObjectParameters};
+pub(crate) use self::mania_object::ObjectParameters;
 
 use self::{
     difficulty_object::ManiaDifficultyObject,

--- a/src/osu/difficulty_object.rs
+++ b/src/osu/difficulty_object.rs
@@ -213,7 +213,7 @@ impl Distances {
 
         let mut lazy_travel_dist: f32 = 0.0;
 
-        for (curr_movement_obj, i) in slider.nested_iter().zip(1..) {
+        for (curr_movement_obj, i) in slider.nested_objects.iter().zip(1..) {
             let mut curr_movement =
                 (curr_movement_obj.pos + hit_object.stack_offset) - curr_cursor_pos;
             let mut curr_movement_len = scaling_factor * curr_movement.length() as f64;
@@ -221,7 +221,7 @@ impl Distances {
             // * Amount of movement required so that the cursor position needs to be updated.
             let mut required_movement = Self::ASSUMED_SLIDER_RADIUS as f64;
 
-            if i == slider.nested_len() {
+            if i == slider.nested_objects.len() {
                 // * The end of a slider has special aim rules due
                 // * to the relaxed time constraint on position.
                 // * There is both a lazy end position as well as the actual end slider position.

--- a/src/osu/gradual_difficulty.rs
+++ b/src/osu/gradual_difficulty.rs
@@ -202,7 +202,7 @@ impl OsuGradualDifficultyAttributes {
             OsuObjectKind::Circle => attrs.n_circles += 1,
             OsuObjectKind::Slider(slider) => {
                 attrs.n_sliders += 1;
-                attrs.max_combo += slider.nested_len();
+                attrs.max_combo += slider.nested_objects.len();
             }
             OsuObjectKind::Spinner { .. } => attrs.n_spinners += 1,
         }

--- a/src/osu/mod.rs
+++ b/src/osu/mod.rs
@@ -10,12 +10,11 @@ use crate::{curve::CurveBuffers, parse::Pos2, AnyStars, Beatmap, GameMode, Mods}
 
 use self::{
     difficulty_object::{Distances, OsuDifficultyObject},
-    osu_object::{ObjectParameters, OsuObject},
     scaling_factor::ScalingFactor,
     skills::{Skill, Skills},
 };
 
-pub use self::{gradual_difficulty::*, gradual_performance::*, pp::*};
+pub use self::{gradual_difficulty::*, gradual_performance::*, osu_object::*, pp::*};
 
 const SECTION_LEN: f64 = 400.0;
 const DIFFICULTY_MULTIPLIER: f64 = 0.0675;

--- a/src/osu/osu_object.rs
+++ b/src/osu/osu_object.rs
@@ -38,7 +38,7 @@ pub enum OsuObjectKind {
     },
 }
 
-/// A [`HitObject`] that was processed a slider for the osu! gamemode.
+/// A [`HitObject`] that was processed as a slider for the osu! gamemode.
 #[derive(Clone, Debug, PartialEq)]
 pub struct OsuSlider {
     /// The endtime of the slider.

--- a/src/osu/osu_object.rs
+++ b/src/osu/osu_object.rs
@@ -10,7 +10,7 @@ const LEGACY_LAST_TICK_OFFSET: f64 = 36.0;
 const BASE_SCORING_DISTANCE: f64 = 100.0;
 
 /// A [`HitObject`] that was processed for the osu! gamemode.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OsuObject {
     /// Position of the object.
     pub pos: Pos2,
@@ -25,7 +25,7 @@ pub struct OsuObject {
 }
 
 /// The type of an [`OsuObject`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum OsuObjectKind {
     /// A hitcircle object.
     Circle,
@@ -39,7 +39,7 @@ pub enum OsuObjectKind {
 }
 
 /// A [`HitObject`] that was processed a slider for the osu! gamemode.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OsuSlider {
     /// The endtime of the slider.
     pub end_time: f64,
@@ -87,7 +87,7 @@ impl OsuSlider {
 }
 
 /// A nested object within a slider.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct NestedObject {
     /// Position of the object.
     ///
@@ -100,7 +100,7 @@ pub struct NestedObject {
 }
 
 /// Type of a [`NestedObject`].
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum NestedObjectKind {
     /// A repeat point.
     Repeat,

--- a/src/taiko/mod.rs
+++ b/src/taiko/mod.rs
@@ -9,7 +9,12 @@ mod taiko_object;
 
 use std::{borrow::Cow, cell::RefCell, rc::Rc};
 
-pub use self::{gradual_difficulty::*, gradual_performance::*, pp::*};
+pub use self::{
+    gradual_difficulty::*, gradual_performance::*, pp::*,
+    taiko_object::TaikoObjectPub as TaikoObject,
+};
+
+pub(crate) use self::taiko_object::IntoTaikoObjectIter;
 
 use crate::{beatmap::BeatmapHitWindows, Beatmap, GameMode, Mods, OsuStars};
 
@@ -17,7 +22,6 @@ use self::{
     colours::ColourDifficultyPreprocessor,
     difficulty_object::{MonoIndex, ObjectLists, TaikoDifficultyObject},
     skills::{Peaks, PeaksDifficultyValues, PeaksRaw, Skill},
-    taiko_object::IntoTaikoObjectIter,
 };
 
 const SECTION_LEN: usize = 400;

--- a/src/taiko/taiko_object.rs
+++ b/src/taiko/taiko_object.rs
@@ -62,3 +62,14 @@ impl ExactSizeIterator for TaikoObjectIter<'_> {
         self.hit_objects.len()
     }
 }
+
+/// A [`HitObject`] that was processed for the osu!taiko gamemode.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct TaikoObjectPub {
+    /// Start time of the object.
+    pub start_time: f64,
+    /// Whether the object is a circle i.e. this is false if the object is a drum roll or a swell.
+    pub is_hit: bool,
+    /// Whether it's a rim or center hit.
+    pub is_rim: bool,
+}


### PR DESCRIPTION
This adds the trait methods `BeatmapExt::{mode}_hitobjects` which return a list of mode-specific processed `HitObject`s.

Resolves #19 