### PR TITLE
perf!: store HitObjectKind::Slider fields in Box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   
 - __Breaking adjustments:__
   - Removed the method `HitObject::end_time` from the public api.
+  - The fields `control_points` and `edge_sounds` of `HitObjectKind::Slider` are now stored in a `Box` rather than a `Vec`.
   - Overhauled gradual calculation. All relevant types are now gated behind the `gradual` feature which must be enabled.
   - `*GradualDifficultyAttributes` has been renamed to `*GradualDifficulty` and `*GradualPerformanceAttributes`
     has been renamed to `*GradualPerformance`.

--- a/src/parse/hitobject.rs
+++ b/src/parse/hitobject.rs
@@ -64,10 +64,10 @@ pub enum HitObjectKind {
         /// The amount of repeat points of the slider.
         repeats: usize,
         /// The control points of the slider.
-        control_points: Vec<PathControlPoint>,
+        control_points: Box<[PathControlPoint]>,
         /// Sample sounds for the slider head, end, and repeat points.
         /// Required for converts.
-        edge_sounds: Vec<u8>,
+        edge_sounds: Box<[u8]>,
     },
     /// A spinner object.
     Spinner {

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -395,8 +395,9 @@ macro_rules! parse_hitobjects_body {
         // the actual `&str` elements transmuted into `(usize, usize)`.
         let mut point_split_raw: Vec<(usize, usize)> = Vec::new();
 
-        // Buffer to re-use for all sliders
+        // Buffers to re-use for all sliders
         let mut vertices = Vec::new();
+        let mut control_points = Vec::new();
 
         'next_line: while next_line!($reader)? != 0 {
             if let Some(bytes) = $reader.get_section() {
@@ -482,8 +483,7 @@ macro_rules! parse_hitobjects_body {
             } else if kind & Self::SLIDER_FLAG > 0 {
                 $self.n_sliders += 1;
 
-                // Control Points: [1, 94872] | Median=3 | Mean=2.9984
-                let mut control_points = Vec::with_capacity(3);
+                control_points.clear();
 
                 let control_point_iter = match split.next() {
                     Some(s) => s.split('|'),
@@ -569,7 +569,7 @@ macro_rules! parse_hitobjects_body {
                         None => None,
                     };
 
-                    let mut edge_sounds = vec![sound; repeats + 2];
+                    let mut edge_sounds = vec![sound; repeats + 2].into_boxed_slice();
 
                     split
                         .next()
@@ -590,7 +590,7 @@ macro_rules! parse_hitobjects_body {
                     HitObjectKind::Slider {
                         repeats,
                         pixel_len,
-                        control_points,
+                        control_points: Box::from(control_points.as_slice()),
                         edge_sounds,
                     }
                 }


### PR DESCRIPTION
Reduces the size of `HitObjectKind` by 16 bytes, shrinking `HitObject`'s size from 88 bytes down to 72. This reduces the amount of allocated space for hit objects in a `Beatmap`.

A quick benchmark also showed an improvement in parsing performance of `1.01 +- 0.03`.