### PR TITLE
feat!: performance calculation with difficulty attributes instead of beatmap

### DIFF
--- a/src/catch/mod.rs
+++ b/src/catch/mod.rs
@@ -274,6 +274,12 @@ impl CatchDifficultyAttributes {
     pub fn max_combo(&self) -> usize {
         self.n_fruits + self.n_droplets
     }
+
+    /// Returns a builder for performance calculation.
+    #[inline]
+    pub fn pp(self) -> CatchPP<'static> {
+        CatchPP::from(self)
+    }
 }
 
 /// The result of a performance calculation on an osu!catch map.

--- a/src/catch/pp.rs
+++ b/src/catch/pp.rs
@@ -418,20 +418,7 @@ impl<'map> CatchPP<'map> {
     /// attributes for catch e.g. if it's [`DifficultyAttributes::Taiko`].
     #[inline]
     pub fn try_from_attributes(attributes: impl CatchAttributeProvider) -> Option<Self> {
-        attributes.attributes().map(|attrs| Self {
-            map_or_attrs: MapOrElse::Else(attrs),
-            mods: 0,
-            acc: None,
-            combo: None,
-
-            n_fruits: None,
-            n_droplets: None,
-            n_tiny_droplets: None,
-            n_tiny_droplet_misses: None,
-            n_misses: None,
-            passed_objects: None,
-            clock_rate: None,
-        })
+        attributes.attributes().map(Self::from)
     }
 }
 
@@ -527,6 +514,31 @@ fn accuracy(
     let denominator = numerator + n_tiny_droplet_misses + n_misses;
 
     numerator as f64 / denominator as f64
+}
+
+impl From<CatchDifficultyAttributes> for CatchPP<'_> {
+    fn from(attrs: CatchDifficultyAttributes) -> Self {
+        Self {
+            map_or_attrs: MapOrElse::Else(attrs),
+            mods: 0,
+            acc: None,
+            combo: None,
+
+            n_fruits: None,
+            n_droplets: None,
+            n_tiny_droplets: None,
+            n_tiny_droplet_misses: None,
+            n_misses: None,
+            passed_objects: None,
+            clock_rate: None,
+        }
+    }
+}
+
+impl From<CatchPerformanceAttributes> for CatchPP<'_> {
+    fn from(attrs: CatchPerformanceAttributes) -> Self {
+        attrs.difficulty.into()
+    }
 }
 
 /// Abstract type to provide flexibility when passing difficulty attributes to a performance calculation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,7 +385,7 @@ impl PerformanceAttributes {
             Self::Osu(attrs) => DifficultyAttributes::Osu(attrs.difficulty.clone()),
             Self::Taiko(attrs) => DifficultyAttributes::Taiko(attrs.difficulty.clone()),
             Self::Catch(attrs) => DifficultyAttributes::Catch(attrs.difficulty.clone()),
-            Self::Mania(attrs) => DifficultyAttributes::Mania(attrs.difficulty),
+            Self::Mania(attrs) => DifficultyAttributes::Mania(attrs.difficulty.clone()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,12 @@ impl DifficultyAttributes {
             Self::Mania(attrs) => attrs.max_combo,
         }
     }
+
+    /// Returns a builder for performance calculation.
+    #[inline]
+    pub fn pp(self) -> AnyPP<'static> {
+        AnyPP::from(self)
+    }
 }
 
 impl From<osu::OsuDifficultyAttributes> for DifficultyAttributes {

--- a/src/mania/gradual_difficulty.rs
+++ b/src/mania/gradual_difficulty.rs
@@ -162,6 +162,7 @@ struct ManiaGradualDifficultyInner {
     diff_objects: Box<[ManiaDifficultyObject]>,
     curr_combo: usize,
     clock_rate: f64,
+    is_convert: bool,
 }
 
 impl ManiaGradualDifficultyInner {
@@ -202,6 +203,7 @@ impl ManiaGradualDifficultyInner {
                     diff_objects: Box::from([]),
                     curr_combo: 0,
                     clock_rate,
+                    is_convert,
                 }
             }
         };
@@ -226,6 +228,7 @@ impl ManiaGradualDifficultyInner {
             diff_objects: diff_objects.into_boxed_slice(),
             curr_combo,
             clock_rate,
+            is_convert,
         }
     }
 
@@ -249,6 +252,8 @@ impl ManiaGradualDifficultyInner {
             stars: self.strain.clone().difficulty_value() * STAR_SCALING_FACTOR,
             hit_window: self.hit_window,
             max_combo: self.curr_combo,
+            is_convert: self.is_convert,
+            n_objects: self.diff_objects.len() + 1,
         })
     }
 

--- a/src/mania/mod.rs
+++ b/src/mania/mod.rs
@@ -230,7 +230,7 @@ struct ManiaResult {
 }
 
 /// The result of a difficulty calculation on an osu!mania map.
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ManiaDifficultyAttributes {
     /// The final star rating.
     pub stars: f64,
@@ -271,7 +271,7 @@ impl ManiaDifficultyAttributes {
 }
 
 /// The result of a performance calculation on an osu!mania map.
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ManiaPerformanceAttributes {
     /// The difficulty attributes that were used for the performance calculation.
     pub difficulty: ManiaDifficultyAttributes,

--- a/src/mania/mod.rs
+++ b/src/mania/mod.rs
@@ -262,6 +262,12 @@ impl ManiaDifficultyAttributes {
     pub fn is_convert(&self) -> bool {
         self.is_convert
     }
+
+    /// Returns a builder for performance calculation.
+    #[inline]
+    pub fn pp(self) -> ManiaPP<'static> {
+        ManiaPP::from(self)
+    }
 }
 
 /// The result of a performance calculation on an osu!mania map.

--- a/src/mania/mod.rs
+++ b/src/mania/mod.rs
@@ -131,12 +131,14 @@ impl<'map> ManiaStars<'map> {
             .clock_rate(clock_rate)
             .hit_windows();
 
+        let n_objects = self.map.hit_objects.len();
         let ManiaResult { strain, max_combo } = calculate_result(self);
 
         ManiaDifficultyAttributes {
             stars: strain.difficulty_value() * STAR_SCALING_FACTOR,
             hit_window,
             max_combo,
+            n_objects,
         }
     }
 
@@ -233,6 +235,8 @@ pub struct ManiaDifficultyAttributes {
     pub stars: f64,
     /// The perceived hit window for an n300 inclusive of rate-adjusting mods (DT/HT/etc).
     pub hit_window: f64,
+    /// The amount of hitobjects in the map.
+    pub n_objects: usize,
     /// The maximum achievable combo.
     pub max_combo: usize,
 }
@@ -242,6 +246,12 @@ impl ManiaDifficultyAttributes {
     #[inline]
     pub fn max_combo(&self) -> usize {
         self.max_combo
+    }
+
+    /// Return the amount of hitobjects.
+    #[inline]
+    pub fn n_objects(&self) -> usize {
+        self.n_objects
     }
 }
 
@@ -273,6 +283,12 @@ impl ManiaPerformanceAttributes {
     #[inline]
     pub fn max_combo(&self) -> usize {
         self.difficulty.max_combo
+    }
+
+    /// Return the amount of hitobjects.
+    #[inline]
+    pub fn n_objects(&self) -> usize {
+        self.difficulty.n_objects
     }
 }
 

--- a/src/mania/mod.rs
+++ b/src/mania/mod.rs
@@ -139,6 +139,7 @@ impl<'map> ManiaStars<'map> {
             hit_window,
             max_combo,
             n_objects,
+            is_convert,
         }
     }
 
@@ -239,6 +240,8 @@ pub struct ManiaDifficultyAttributes {
     pub n_objects: usize,
     /// The maximum achievable combo.
     pub max_combo: usize,
+    /// Whether the [`Beatmap`] was a convert i.e. an osu!standard map.
+    pub is_convert: bool,
 }
 
 impl ManiaDifficultyAttributes {
@@ -252,6 +255,12 @@ impl ManiaDifficultyAttributes {
     #[inline]
     pub fn n_objects(&self) -> usize {
         self.n_objects
+    }
+
+    /// Whether the [`Beatmap`] was a convert i.e. an osu!standard map.
+    #[inline]
+    pub fn is_convert(&self) -> bool {
+        self.is_convert
     }
 }
 
@@ -289,6 +298,12 @@ impl ManiaPerformanceAttributes {
     #[inline]
     pub fn n_objects(&self) -> usize {
         self.difficulty.n_objects
+    }
+
+    /// Whether the [`Beatmap`] was a convert i.e. an osu!standard map.
+    #[inline]
+    pub fn is_convert(&self) -> bool {
+        self.difficulty.is_convert
     }
 }
 

--- a/src/mania/pp.rs
+++ b/src/mania/pp.rs
@@ -741,7 +741,13 @@ impl<'map> ManiaPP<'map> {
         calculator.calculate()
     }
 
-    /// TODO: docs
+    /// Try to create [`ManiaPP`] through [`OsuPP`].
+    ///
+    /// Returns `None` if [`OsuPP`] already replaced its internal [`Beatmap`]
+    /// with [`OsuDifficultyAttributes`], i.e. if [`OsuPP::attributes`]
+    /// or [`OsuPP::generate_state`] was called.
+    ///
+    /// [`OsuDifficultyAttributes`]: crate::osu::OsuDifficultyAttributes
     #[inline]
     pub fn try_from_osu(osu: OsuPP<'map>) -> Option<Self> {
         let OsuPP {
@@ -778,6 +784,37 @@ impl<'map> ManiaPP<'map> {
             n_misses,
             acc,
             hitresult_priority,
+        })
+    }
+
+    /// Try to create [`ManiaPP`] through a [`ManiaAttributeProvider`].
+    ///
+    /// If you already calculated the attributes for the current map-mod
+    /// combination, the [`Beatmap`] is no longer necessary to calculate
+    /// performance attributes so this method can be used instead of
+    /// [`ManiaPP::new`].
+    ///
+    /// Returns `None` only if the [`ManiaAttributeProvider`] did not contain
+    /// attributes for mania e.g. if it's [`DifficultyAttributes::Taiko`].
+    #[inline]
+    pub fn try_from_attributes(
+        attributes: impl ManiaAttributeProvider,
+        is_convert: bool,
+    ) -> Option<Self> {
+        attributes.attributes().map(|attrs| Self {
+            is_convert,
+            map_or_attrs: MapOrElse::Else(attrs),
+            mods: 0,
+            passed_objects: None,
+            clock_rate: None,
+            n320: None,
+            n300: None,
+            n200: None,
+            n100: None,
+            n50: None,
+            n_misses: None,
+            acc: None,
+            hitresult_priority: None,
         })
     }
 }

--- a/src/mania/pp.rs
+++ b/src/mania/pp.rs
@@ -229,7 +229,7 @@ impl<'map> ManiaPP<'map> {
     pub fn generate_state(&mut self) -> ManiaScoreState {
         let attrs = match self.map_or_attrs {
             MapOrElse::Map(ref map) => {
-                let attrs = self.generate_attributes(&map);
+                let attrs = self.generate_attributes(map);
 
                 self.map_or_attrs.else_or_insert(attrs)
             }
@@ -728,7 +728,7 @@ impl<'map> ManiaPP<'map> {
     fn generate_attributes(&self, map: &Beatmap) -> ManiaDifficultyAttributes {
         let is_convert = self
             .is_convert_overwrite
-            .unwrap_or_else(|| match self.map_or_attrs {
+            .unwrap_or(match self.map_or_attrs {
                 MapOrElse::Map(ref map) => matches!(map, Cow::Owned(_)),
                 MapOrElse::Else(ref attrs) => attrs.is_convert,
             });

--- a/src/mania/pp.rs
+++ b/src/mania/pp.rs
@@ -803,21 +803,7 @@ impl<'map> ManiaPP<'map> {
     /// attributes for mania e.g. if it's [`DifficultyAttributes::Taiko`].
     #[inline]
     pub fn try_from_attributes(attributes: impl ManiaAttributeProvider) -> Option<Self> {
-        attributes.attributes().map(|attrs| Self {
-            map_or_attrs: MapOrElse::Else(attrs),
-            is_convert_overwrite: None,
-            mods: 0,
-            passed_objects: None,
-            clock_rate: None,
-            n320: None,
-            n300: None,
-            n200: None,
-            n100: None,
-            n50: None,
-            n_misses: None,
-            acc: None,
-            hitresult_priority: None,
-        })
+        attributes.attributes().map(Self::from)
     }
 }
 
@@ -911,6 +897,32 @@ fn accuracy(
     let denominator = 6 * (n320 + n300 + n200 + n100 + n50 + n_misses);
 
     numerator as f64 / denominator as f64
+}
+
+impl From<ManiaDifficultyAttributes> for ManiaPP<'_> {
+    fn from(attrs: ManiaDifficultyAttributes) -> Self {
+        Self {
+            map_or_attrs: MapOrElse::Else(attrs),
+            is_convert_overwrite: None,
+            mods: 0,
+            passed_objects: None,
+            clock_rate: None,
+            n320: None,
+            n300: None,
+            n200: None,
+            n100: None,
+            n50: None,
+            n_misses: None,
+            acc: None,
+            hitresult_priority: None,
+        }
+    }
+}
+
+impl From<ManiaPerformanceAttributes> for ManiaPP<'_> {
+    fn from(attrs: ManiaPerformanceAttributes) -> Self {
+        attrs.difficulty.into()
+    }
 }
 
 /// Abstract type to provide flexibility when passing difficulty attributes to a performance calculation.

--- a/src/mania/pp.rs
+++ b/src/mania/pp.rs
@@ -227,16 +227,22 @@ impl<'map> ManiaPP<'map> {
 
     /// Create the [`ManiaScoreState`] that will be used for performance calculation.
     pub fn generate_state(&mut self) -> ManiaScoreState {
-        let attrs = match self.map_or_attrs {
-            MapOrElse::Map(ref map) => {
-                let attrs = self.generate_attributes(map);
+        let n_objects = match self.passed_objects {
+            Some(passed) => passed,
+            None => {
+                let attrs = match self.map_or_attrs {
+                    MapOrElse::Map(ref map) => {
+                        let attrs = self.generate_attributes(map);
 
-                self.map_or_attrs.else_or_insert(attrs)
+                        self.map_or_attrs.else_or_insert(attrs)
+                    }
+                    MapOrElse::Else(ref attrs) => attrs,
+                };
+
+                attrs.n_objects
             }
-            MapOrElse::Else(ref attrs) => attrs,
         };
 
-        let n_objects = attrs.n_objects();
         let priority = self.hitresult_priority.unwrap_or_default();
 
         let n_misses = self.n_misses.map_or(0, |n| n.min(n_objects));

--- a/src/osu/mod.rs
+++ b/src/osu/mod.rs
@@ -589,6 +589,12 @@ impl OsuDifficultyAttributes {
     pub fn max_combo(&self) -> usize {
         self.max_combo
     }
+
+    /// Return the amount of hitobjects.
+    #[inline]
+    pub fn n_objects(&self) -> usize {
+        self.n_circles + self.n_sliders + self.n_spinners
+    }
 }
 
 /// The result of a performance calculation on an osu!standard map.
@@ -627,6 +633,11 @@ impl OsuPerformanceAttributes {
     #[inline]
     pub fn max_combo(&self) -> usize {
         self.difficulty.max_combo
+    }
+    /// Return the amount of hitobjects.
+    #[inline]
+    pub fn n_objects(&self) -> usize {
+        self.difficulty.n_objects()
     }
 }
 

--- a/src/osu/mod.rs
+++ b/src/osu/mod.rs
@@ -595,6 +595,12 @@ impl OsuDifficultyAttributes {
     pub fn n_objects(&self) -> usize {
         self.n_circles + self.n_sliders + self.n_spinners
     }
+
+    /// Returns a builder for performance calculation.
+    #[inline]
+    pub fn pp(self) -> OsuPP<'static> {
+        OsuPP::from(self)
+    }
 }
 
 /// The result of a performance calculation on an osu!standard map.

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -434,7 +434,7 @@ impl<'map> OsuPP<'map> {
     /// [`OsuPP::new`].
     ///
     /// Returns `None` only if the [`OsuAttributeProvider`] did not contain
-    /// attributes for catch e.g. if it's [`DifficultyAttributes::Taiko`].
+    /// attributes for osu e.g. if it's [`DifficultyAttributes::Taiko`].
     #[inline]
     pub fn try_from_attributes(attributes: impl OsuAttributeProvider) -> Option<Self> {
         attributes.attributes().map(Self::from)

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -437,20 +437,7 @@ impl<'map> OsuPP<'map> {
     /// attributes for catch e.g. if it's [`DifficultyAttributes::Taiko`].
     #[inline]
     pub fn try_from_attributes(attributes: impl OsuAttributeProvider) -> Option<Self> {
-        attributes.attributes().map(|attrs| Self {
-            map_or_attrs: MapOrElse::Else(attrs),
-            mods: 0,
-            acc: None,
-            combo: None,
-
-            n300: None,
-            n100: None,
-            n50: None,
-            n_misses: None,
-            passed_objects: None,
-            clock_rate: None,
-            hitresult_priority: None,
-        })
+        attributes.attributes().map(Self::from)
     }
 }
 
@@ -780,6 +767,33 @@ fn accuracy(n300: usize, n100: usize, n50: usize, n_misses: usize) -> f64 {
     let denominator = 6 * (n300 + n100 + n50 + n_misses);
 
     numerator as f64 / denominator as f64
+}
+
+impl From<OsuDifficultyAttributes> for OsuPP<'_> {
+    #[inline]
+    fn from(attrs: OsuDifficultyAttributes) -> Self {
+        Self {
+            map_or_attrs: MapOrElse::Else(attrs),
+            mods: 0,
+            acc: None,
+            combo: None,
+
+            n300: None,
+            n100: None,
+            n50: None,
+            n_misses: None,
+            passed_objects: None,
+            clock_rate: None,
+            hitresult_priority: None,
+        }
+    }
+}
+
+impl From<OsuPerformanceAttributes> for OsuPP<'_> {
+    #[inline]
+    fn from(attrs: OsuPerformanceAttributes) -> Self {
+        attrs.difficulty.into()
+    }
 }
 
 /// Abstract type to provide flexibility when passing difficulty attributes to a performance calculation.

--- a/src/pp.rs
+++ b/src/pp.rs
@@ -60,6 +60,8 @@ impl<'map> AnyPP<'map> {
         }
     }
 
+    // TODO: from_attributes method
+
     /// Consume the performance calculator and calculate
     /// performance attributes for the given parameters.
     #[inline]

--- a/src/pp.rs
+++ b/src/pp.rs
@@ -86,16 +86,12 @@ impl<'map> AnyPP<'map> {
     }
 
     /// If the map is an osu!standard map, convert it to another mode.
+    // TODO: option necessary?
     #[inline]
-    pub fn mode(self, mode: GameMode) -> Self {
+    pub fn try_mode(self, mode: GameMode) -> Option<Self> {
         match self {
-            AnyPP::Osu(o) => match mode {
-                GameMode::Osu => AnyPP::Osu(o),
-                GameMode::Taiko => AnyPP::Taiko(o.into()),
-                GameMode::Catch => AnyPP::Catch(o.into()),
-                GameMode::Mania => AnyPP::Mania(o.into()),
-            },
-            other => other,
+            AnyPP::Osu(o) => o.try_mode(mode),
+            other => Some(other),
         }
     }
 

--- a/src/pp.rs
+++ b/src/pp.rs
@@ -67,7 +67,7 @@ impl<'map> AnyPP<'map> {
     /// as when the attributes were calculated.
     #[inline]
     pub fn from_attributes(attributes: impl AttributeProvider) -> Self {
-        Self::from(attributes.attributes())
+        Self::from(attributes)
     }
 
     /// Consume the performance calculator and calculate
@@ -296,22 +296,19 @@ impl<'map> AnyPP<'map> {
     }
 }
 
-impl From<DifficultyAttributes> for AnyPP<'_> {
+impl<A: AttributeProvider> From<A> for AnyPP<'_> {
     #[inline]
-    fn from(attrs: DifficultyAttributes) -> Self {
-        match attrs {
-            DifficultyAttributes::Osu(attrs) => Self::Osu(attrs.pp()),
-            DifficultyAttributes::Taiko(attrs) => Self::Taiko(attrs.pp()),
-            DifficultyAttributes::Catch(attrs) => Self::Catch(attrs.pp()),
-            DifficultyAttributes::Mania(attrs) => Self::Mania(attrs.pp()),
+    fn from(attrs: A) -> Self {
+        fn inner(attrs: DifficultyAttributes) -> AnyPP<'static> {
+            match attrs {
+                DifficultyAttributes::Osu(attrs) => AnyPP::Osu(attrs.pp()),
+                DifficultyAttributes::Taiko(attrs) => AnyPP::Taiko(attrs.pp()),
+                DifficultyAttributes::Catch(attrs) => AnyPP::Catch(attrs.pp()),
+                DifficultyAttributes::Mania(attrs) => AnyPP::Mania(attrs.pp()),
+            }
         }
-    }
-}
 
-impl From<PerformanceAttributes> for AnyPP<'_> {
-    #[inline]
-    fn from(attrs: PerformanceAttributes) -> Self {
-        attrs.difficulty_attributes().into()
+        inner(attrs.attributes())
     }
 }
 

--- a/src/pp.rs
+++ b/src/pp.rs
@@ -96,7 +96,10 @@ impl<'map> AnyPP<'map> {
     }
 
     /// If the map is an osu!standard map, convert it to another mode.
-    // TODO: option necessary?
+    ///
+    /// Returns `None` if `self` already replaced it's internal [`Beatmap`]
+    /// with difficulty attributes, i.e. if [`AnyPP::attributes`]
+    /// or [`AnyPP::generate_state`] was called.
     #[inline]
     pub fn try_mode(self, mode: GameMode) -> Option<Self> {
         match self {

--- a/src/pp.rs
+++ b/src/pp.rs
@@ -60,7 +60,15 @@ impl<'map> AnyPP<'map> {
         }
     }
 
-    // TODO: from_attributes method
+    /// Create a new performance calculator through previously calculated
+    /// attributes.
+    ///
+    /// Note that the map, mods, and passed object count should be the same
+    /// as when the attributes were calculated.
+    #[inline]
+    pub fn from_attributes(attributes: impl AttributeProvider) -> Self {
+        Self::from(attributes.attributes())
+    }
 
     /// Consume the performance calculator and calculate
     /// performance attributes for the given parameters.
@@ -282,6 +290,25 @@ impl<'map> AnyPP<'map> {
             Self::Catch(f) => f.generate_state().into(),
             Self::Mania(m) => m.generate_state().into(),
         }
+    }
+}
+
+impl From<DifficultyAttributes> for AnyPP<'_> {
+    #[inline]
+    fn from(attrs: DifficultyAttributes) -> Self {
+        match attrs {
+            DifficultyAttributes::Osu(attrs) => Self::Osu(attrs.pp()),
+            DifficultyAttributes::Taiko(attrs) => Self::Taiko(attrs.pp()),
+            DifficultyAttributes::Catch(attrs) => Self::Catch(attrs.pp()),
+            DifficultyAttributes::Mania(attrs) => Self::Mania(attrs.pp()),
+        }
+    }
+}
+
+impl From<PerformanceAttributes> for AnyPP<'_> {
+    #[inline]
+    fn from(attrs: PerformanceAttributes) -> Self {
+        attrs.difficulty_attributes().into()
     }
 }
 

--- a/src/taiko/gradual_difficulty.rs
+++ b/src/taiko/gradual_difficulty.rs
@@ -268,7 +268,6 @@ impl Iterator for TaikoGradualDifficulty {
                     FirstTwoCombos::Both => self.attrs.max_combo = 2,
                 }
             }
-            _ => unreachable!(),
         }
 
         for _ in 0..take {

--- a/src/taiko/mod.rs
+++ b/src/taiko/mod.rs
@@ -170,6 +170,7 @@ impl<'map> TaikoStars<'map> {
             hit_window,
             stars: star_rating,
             max_combo,
+            is_convert,
         }
     }
 
@@ -309,6 +310,8 @@ pub struct TaikoDifficultyAttributes {
     pub stars: f64,
     /// The maximum combo.
     pub max_combo: usize,
+    /// Whether the [`Beatmap`] was a convert i.e. an osu!standard map.
+    pub is_convert: bool,
 }
 
 impl TaikoDifficultyAttributes {
@@ -316,6 +319,12 @@ impl TaikoDifficultyAttributes {
     #[inline]
     pub fn max_combo(&self) -> usize {
         self.max_combo
+    }
+
+    /// Whether the [`Beatmap`] was a convert i.e. an osu!standard map.
+    #[inline]
+    pub fn is_convert(&self) -> bool {
+        self.is_convert
     }
 }
 
@@ -351,6 +360,12 @@ impl TaikoPerformanceAttributes {
     #[inline]
     pub fn max_combo(&self) -> usize {
         self.difficulty.max_combo
+    }
+
+    /// Whether the [`Beatmap`] was a convert i.e. an osu!standard map.
+    #[inline]
+    pub fn is_convert(&self) -> bool {
+        self.difficulty.is_convert
     }
 }
 

--- a/src/taiko/mod.rs
+++ b/src/taiko/mod.rs
@@ -326,6 +326,12 @@ impl TaikoDifficultyAttributes {
     pub fn is_convert(&self) -> bool {
         self.is_convert
     }
+
+    /// Returns a builder for performance calculation.
+    #[inline]
+    pub fn pp(self) -> TaikoPP<'static> {
+        TaikoPP::from(self)
+    }
 }
 
 /// The result of a performance calculation on an osu!taiko map.

--- a/src/taiko/pp.rs
+++ b/src/taiko/pp.rs
@@ -381,19 +381,7 @@ impl<'map> TaikoPP<'map> {
     /// attributes for catch e.g. if it's [`DifficultyAttributes::Mania`].
     #[inline]
     pub fn try_from_attributes(attributes: impl TaikoAttributeProvider) -> Option<Self> {
-        attributes.attributes().map(|attrs| Self {
-            map_or_attrs: MapOrElse::Else(attrs),
-            is_convert_overwrite: None,
-            mods: 0,
-            combo: None,
-            acc: None,
-            n_misses: None,
-            passed_objects: None,
-            clock_rate: None,
-            n300: None,
-            n100: None,
-            hitresult_priority: None,
-        })
+        attributes.attributes().map(Self::from)
     }
 }
 
@@ -523,6 +511,30 @@ fn accuracy(n300: usize, n100: usize, n_misses: usize) -> f64 {
     let denominator = 2 * (n300 + n100 + n_misses);
 
     numerator as f64 / denominator as f64
+}
+
+impl From<TaikoDifficultyAttributes> for TaikoPP<'_> {
+    fn from(attrs: TaikoDifficultyAttributes) -> Self {
+        Self {
+            map_or_attrs: MapOrElse::Else(attrs),
+            is_convert_overwrite: None,
+            mods: 0,
+            combo: None,
+            acc: None,
+            n_misses: None,
+            passed_objects: None,
+            clock_rate: None,
+            n300: None,
+            n100: None,
+            hitresult_priority: None,
+        }
+    }
+}
+
+impl From<TaikoPerformanceAttributes> for TaikoPP<'_> {
+    fn from(attrs: TaikoPerformanceAttributes) -> Self {
+        attrs.difficulty.into()
+    }
 }
 
 /// Abstract type to provide flexibility when passing difficulty attributes to a performance calculation.

--- a/src/taiko/pp.rs
+++ b/src/taiko/pp.rs
@@ -378,7 +378,7 @@ impl<'map> TaikoPP<'map> {
     /// [`TaikoPP::new`].
     ///
     /// Returns `None` only if the [`TaikoAttributeProvider`] did not contain
-    /// attributes for catch e.g. if it's [`DifficultyAttributes::Mania`].
+    /// attributes for taiko e.g. if it's [`DifficultyAttributes::Mania`].
     #[inline]
     pub fn try_from_attributes(attributes: impl TaikoAttributeProvider) -> Option<Self> {
         attributes.attributes().map(Self::from)

--- a/src/taiko/pp.rs
+++ b/src/taiko/pp.rs
@@ -200,7 +200,7 @@ impl<'map> TaikoPP<'map> {
     pub fn generate_state(&mut self) -> TaikoScoreState {
         let attrs = match self.map_or_attrs {
             MapOrElse::Map(ref map) => {
-                let attrs = self.generate_attributes(&map);
+                let attrs = self.generate_attributes(map);
 
                 self.map_or_attrs.else_or_insert(attrs)
             }
@@ -308,7 +308,7 @@ impl<'map> TaikoPP<'map> {
     fn generate_attributes(&self, map: &Beatmap) -> TaikoDifficultyAttributes {
         let is_convert = self
             .is_convert_overwrite
-            .unwrap_or_else(|| match self.map_or_attrs {
+            .unwrap_or(match self.map_or_attrs {
                 MapOrElse::Map(ref map) => matches!(map, Cow::Owned(_)),
                 MapOrElse::Else(ref attrs) => attrs.is_convert,
             });

--- a/src/util/map_or_else.rs
+++ b/src/util/map_or_else.rs
@@ -1,0 +1,66 @@
+use crate::Beatmap;
+
+#[derive(Clone, Debug)]
+pub(crate) enum MapOrElse<M, E> {
+    Map(M),
+    Else(E),
+}
+
+impl<M, E> MapOrElse<M, E>
+where
+    M: AsRef<Beatmap>,
+{
+    // /// Take out the `Else` value of `self` and return it.
+    // ///
+    // /// If `self` is of variant `Else`, `E::default()` will be left in place.
+    // pub(crate) fn take(&mut self) -> MapOrElse<MapRef<'_>, E>
+    // where
+    //     E: Default,
+    // {
+    //     match self {
+    //         Self::Map(ref map) => MapOrElse::from(map.deref()),
+    //         Self::Else(ref mut other) => MapOrElse::Else(mem::take(other)),
+    //     }
+    // }
+
+    /// Return a mutable reference to `Else`.
+    ///
+    /// If `self` is of variant `Map`, store `other` in `self`, and return a
+    /// mutable reference to it.
+    pub(crate) fn else_or_insert(&mut self, other: E) -> &mut E {
+        match self {
+            MapOrElse::Map(_) => {
+                *self = Self::Else(other);
+
+                let Self::Else(ref mut other) = self else {
+                    unreachable!()
+                };
+
+                other
+            }
+            MapOrElse::Else(ref mut other) => other,
+        }
+    }
+}
+
+impl<'map, E> From<&'map Beatmap> for MapOrElse<MapRef<'map>, E> {
+    fn from(map: &'map Beatmap) -> Self {
+        Self::Map(MapRef(map))
+    }
+}
+
+/// References don't implement [`Deref`] so we implement a wrapper type.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct MapRef<'map>(&'map Beatmap);
+
+impl<'map> MapRef<'map> {
+    pub(crate) fn into_inner(self) -> &'map Beatmap {
+        self.0
+    }
+}
+
+impl AsRef<Beatmap> for MapRef<'_> {
+    fn as_ref(&self) -> &Beatmap {
+        self.0
+    }
+}

--- a/src/util/map_or_else.rs
+++ b/src/util/map_or_else.rs
@@ -10,19 +10,6 @@ impl<M, E> MapOrElse<M, E>
 where
     M: AsRef<Beatmap>,
 {
-    // /// Take out the `Else` value of `self` and return it.
-    // ///
-    // /// If `self` is of variant `Else`, `E::default()` will be left in place.
-    // pub(crate) fn take(&mut self) -> MapOrElse<MapRef<'_>, E>
-    // where
-    //     E: Default,
-    // {
-    //     match self {
-    //         Self::Map(ref map) => MapOrElse::from(map.deref()),
-    //         Self::Else(ref mut other) => MapOrElse::Else(mem::take(other)),
-    //     }
-    // }
-
     /// Return a mutable reference to `Else`.
     ///
     /// If `self` is of variant `Map`, store `other` in `self`, and return a

--- a/src/util/map_or_else.rs
+++ b/src/util/map_or_else.rs
@@ -6,10 +6,7 @@ pub(crate) enum MapOrElse<M, E> {
     Else(E),
 }
 
-impl<M, E> MapOrElse<M, E>
-where
-    M: AsRef<Beatmap>,
-{
+impl<M, E> MapOrElse<M, E> {
     /// Return a mutable reference to `Else`.
     ///
     /// If `self` is of variant `Map`, store `other` in `self`, and return a

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -2,9 +2,14 @@ mod byte_hasher;
 mod compact_vec;
 mod float_ext;
 mod limited_queue;
+mod map_or_else;
 mod tandem_sort;
 
 pub(crate) use self::{
-    byte_hasher::ByteHasher, compact_vec::CompactVec, float_ext::FloatExt,
-    limited_queue::LimitedQueue, tandem_sort::TandemSorter,
+    byte_hasher::ByteHasher,
+    compact_vec::CompactVec,
+    float_ext::FloatExt,
+    limited_queue::LimitedQueue,
+    map_or_else::{MapOrElse, MapRef},
+    tandem_sort::TandemSorter,
 };

--- a/tests/common/mode.rs
+++ b/tests/common/mode.rs
@@ -52,6 +52,7 @@ impl_mode! {
         hit_window: 35.0,
         stars: 2.9778030386845606,
         max_combo: 289,
+        is_convert: false,
     };
     Catch: 2118524, CatchDifficultyAttributes {
         stars: 3.2502669316166624,
@@ -65,5 +66,6 @@ impl_mode! {
         hit_window: 40.0,
         max_combo: 956,
         n_objects: 594,
+        is_convert: false,
     };
 }

--- a/tests/common/mode.rs
+++ b/tests/common/mode.rs
@@ -64,5 +64,6 @@ impl_mode! {
         stars: 3.441830819988125,
         hit_window: 40.0,
         max_combo: 956,
+        n_objects: 594,
     };
 }

--- a/tests/gradual_mania.rs
+++ b/tests/gradual_mania.rs
@@ -71,7 +71,7 @@ fn gradual_complete_next() {
 
         let next_gradual_owned = gradual_owned.next(state.clone()).unwrap();
 
-        let regular_calc = ManiaPP::new(map)
+        let mut regular_calc = ManiaPP::new(map)
             .mods(mods)
             .passed_objects(i)
             .state(state.clone());

--- a/tests/perf_via_diff.rs
+++ b/tests/perf_via_diff.rs
@@ -1,0 +1,73 @@
+#![cfg(not(any(feature = "async_tokio", feature = "async_std")))]
+
+use rosu_pp::{CatchPP, ManiaPP, OsuPP, TaikoPP};
+
+mod common;
+
+#[test]
+fn osu() {
+    let map = test_map!(Osu);
+
+    let mods = 8 + 64;
+    let misses = 2;
+
+    let regular = OsuPP::new(map).mods(mods).n_misses(misses).calculate();
+
+    let via_diff = OsuPP::from(regular.difficulty.clone())
+        .mods(mods)
+        .n_misses(misses)
+        .calculate();
+
+    assert_eq!(regular, via_diff);
+}
+
+#[test]
+fn taiko() {
+    let map = test_map!(Taiko);
+
+    let mods = 8 + 64;
+    let misses = 2;
+
+    let regular = TaikoPP::new(map).mods(mods).n_misses(misses).calculate();
+
+    let via_diff = TaikoPP::from(regular.difficulty.clone())
+        .mods(mods)
+        .n_misses(misses)
+        .calculate();
+
+    assert_eq!(regular, via_diff);
+}
+
+#[test]
+fn catch() {
+    let map = test_map!(Catch);
+
+    let mods = 8 + 64;
+    let misses = 2;
+
+    let regular = CatchPP::new(map).mods(mods).misses(misses).calculate();
+
+    let via_diff = CatchPP::from(regular.difficulty.clone())
+        .mods(mods)
+        .misses(misses)
+        .calculate();
+
+    assert_eq!(regular, via_diff);
+}
+
+#[test]
+fn mania() {
+    let map = test_map!(Mania);
+
+    let mods = 8 + 64;
+    let misses = 2;
+
+    let regular = ManiaPP::new(map).mods(mods).n_misses(misses).calculate();
+
+    let via_diff = ManiaPP::from(regular.difficulty.clone())
+        .mods(mods)
+        .n_misses(misses)
+        .calculate();
+
+    assert_eq!(regular, via_diff);
+}


### PR DESCRIPTION
As per #28, performance calculation requires a `Beatmap` only for the difficulty attribute calculation and the amount of hitobjects. The former can already be avoided by specifying attributes manually. The later could be avoided by specifying `passed_objects` for osu!standard but in mania there was no way to avoid it.

This PR adds a way to calculate performance attributes straight from difficulty attributes without the need of a `Beatmap` at all.

Some attribute structs' fields were modified, as well as some method signatures to convert between modes so this introduces breaking changes.