### PR TITLE
refactor!: add small tick hits

### DIFF
--- a/src/any/performance/mod.rs
+++ b/src/any/performance/mod.rs
@@ -336,7 +336,18 @@ impl<'map> Performance<'map> {
     ///   slider heads, ticks, and repeats
     pub fn large_tick_hits(self, large_tick_hits: u32) -> Self {
         if let Self::Osu(osu) = self {
-            Self::Osu(osu.n_large_ticks(large_tick_hits))
+            Self::Osu(osu.large_tick_hits(large_tick_hits))
+        } else {
+            self
+        }
+    }
+
+    /// Specify the amount of "small tick" hits.
+    ///
+    /// Only relevant for osu!standard lazer scores without slider accuracy.
+    pub fn small_ticks_hits(self, small_tick_hits: u32) -> Self {
+        if let Self::Osu(osu) = self {
+            Self::Osu(osu.small_tick_hits(small_tick_hits))
         } else {
             self
         }
@@ -344,13 +355,10 @@ impl<'map> Performance<'map> {
 
     /// Specify the amount of hit slider ends.
     ///
-    /// Only relevant for osu!standard.
-    ///
-    /// osu! calls this value "slider tail hits" without the classic
-    /// mod and "small tick hits" with the classic mod.
-    pub fn n_slider_ends(self, n_slider_ends: u32) -> Self {
+    /// Only relevant for osu!standard lazer scores with slider accuracy.
+    pub fn slider_end_hits(self, slider_end_hits: u32) -> Self {
         if let Self::Osu(osu) = self {
-            Self::Osu(osu.n_slider_ends(n_slider_ends))
+            Self::Osu(osu.slider_end_hits(slider_end_hits))
         } else {
             self
         }

--- a/src/any/performance/mod.rs
+++ b/src/any/performance/mod.rs
@@ -344,7 +344,8 @@ impl<'map> Performance<'map> {
 
     /// Specify the amount of "small tick" hits.
     ///
-    /// Only relevant for osu!standard lazer scores without slider accuracy.
+    /// Only relevant for osu!standard lazer scores without slider accuracy. In
+    /// that case, this value is the amount of slider tail hits.
     pub fn small_ticks_hits(self, small_tick_hits: u32) -> Self {
         if let Self::Osu(osu) = self {
             Self::Osu(osu.small_tick_hits(small_tick_hits))

--- a/src/any/score_state.rs
+++ b/src/any/score_state.rs
@@ -23,7 +23,16 @@ pub struct ScoreState {
     ///   slider ticks and repeats
     /// - if set on osu!lazer *with* `CL`, this field is the amount of hit
     ///   slider heads, ticks, and repeats
+    ///
+    /// Only relevant for osu!lazer.
     pub osu_large_tick_hits: u32,
+    /// "Small ticks" hits for osu!standard.
+    ///
+    /// These are essentially the slider end hits for lazer scores without
+    /// slider accuracy.
+    ///
+    /// Only relevant for osu!lazer.
+    pub osu_small_tick_hits: u32,
     /// Amount of successfully hit slider ends.
     ///
     /// Only relevant for osu!standard in lazer.
@@ -49,6 +58,7 @@ impl ScoreState {
         Self {
             max_combo: 0,
             osu_large_tick_hits: 0,
+            osu_small_tick_hits: 0,
             slider_end_hits: 0,
             n_geki: 0,
             n_katu: 0,
@@ -82,6 +92,7 @@ impl From<ScoreState> for OsuScoreState {
         Self {
             max_combo: state.max_combo,
             large_tick_hits: state.osu_large_tick_hits,
+            small_tick_hits: state.osu_small_tick_hits,
             slider_end_hits: state.slider_end_hits,
             n300: state.n300,
             n100: state.n100,
@@ -133,6 +144,7 @@ impl From<OsuScoreState> for ScoreState {
         Self {
             max_combo: state.max_combo,
             osu_large_tick_hits: state.large_tick_hits,
+            osu_small_tick_hits: state.small_tick_hits,
             slider_end_hits: state.slider_end_hits,
             n_geki: 0,
             n_katu: 0,
@@ -149,6 +161,7 @@ impl From<TaikoScoreState> for ScoreState {
         Self {
             max_combo: state.max_combo,
             osu_large_tick_hits: 0,
+            osu_small_tick_hits: 0,
             slider_end_hits: 0,
             n_geki: 0,
             n_katu: 0,
@@ -165,6 +178,7 @@ impl From<CatchScoreState> for ScoreState {
         Self {
             max_combo: state.max_combo,
             osu_large_tick_hits: 0,
+            osu_small_tick_hits: 0,
             slider_end_hits: 0,
             n_geki: 0,
             n_katu: state.tiny_droplet_misses,
@@ -181,6 +195,7 @@ impl From<ManiaScoreState> for ScoreState {
         Self {
             max_combo: 0,
             osu_large_tick_hits: 0,
+            osu_small_tick_hits: 0,
             slider_end_hits: 0,
             n_geki: state.n320,
             n_katu: state.n200,

--- a/src/catch/performance/mod.rs
+++ b/src/catch/performance/mod.rs
@@ -474,6 +474,7 @@ impl<'map> TryFrom<OsuPerformance<'map>> for CatchPerformance<'map> {
             acc,
             combo,
             large_tick_hits: _,
+            small_tick_hits: _,
             slider_end_hits: _,
             n300,
             n100,

--- a/src/mania/performance/mod.rs
+++ b/src/mania/performance/mod.rs
@@ -845,6 +845,7 @@ impl<'map> TryFrom<OsuPerformance<'map>> for ManiaPerformance<'map> {
             acc,
             combo: _,
             large_tick_hits: _,
+            small_tick_hits: _,
             slider_end_hits: _,
             n300,
             n100,

--- a/src/osu/performance/gradual.rs
+++ b/src/osu/performance/gradual.rs
@@ -151,30 +151,30 @@ mod tests {
         for i in 1.. {
             state.misses += 1;
 
-            let Some(next_gradual) = gradual.next(state) else {
+            let Some(next_gradual) = gradual.next(state.clone()) else {
                 assert_eq!(i, hit_objects_len + 1);
-                assert!(gradual_2nd.last(state).is_some() || hit_objects_len % 2 == 0);
-                assert!(gradual_3rd.last(state).is_some() || hit_objects_len % 3 == 0);
+                assert!(gradual_2nd.last(state.clone()).is_some() || hit_objects_len % 2 == 0);
+                assert!(gradual_3rd.last(state.clone()).is_some() || hit_objects_len % 3 == 0);
                 break;
             };
 
             if i % 2 == 0 {
-                let next_gradual_2nd = gradual_2nd.nth(state, 1).unwrap();
+                let next_gradual_2nd = gradual_2nd.nth(state.clone(), 1).unwrap();
                 assert_eq!(next_gradual, next_gradual_2nd);
             }
 
             if i % 3 == 0 {
-                let next_gradual_3rd = gradual_3rd.nth(state, 2).unwrap();
+                let next_gradual_3rd = gradual_3rd.nth(state.clone(), 2).unwrap();
                 assert_eq!(next_gradual, next_gradual_3rd);
             }
 
             let mut regular_calc = OsuPerformance::new(&map)
                 .difficulty(difficulty.clone())
                 .passed_objects(i as u32)
-                .state(state);
+                .state(state.clone());
 
             let regular_state = regular_calc.generate_state().unwrap();
-            assert_eq!(state, regular_state);
+            assert_eq!(state.clone(), regular_state);
 
             let expected = regular_calc.calculate().unwrap();
 

--- a/src/osu/performance/mod.rs
+++ b/src/osu/performance/mod.rs
@@ -30,6 +30,7 @@ pub struct OsuPerformance<'map> {
     pub(crate) acc: Option<f64>,
     pub(crate) combo: Option<u32>,
     pub(crate) large_tick_hits: Option<u32>,
+    pub(crate) small_tick_hits: Option<u32>,
     pub(crate) slider_end_hits: Option<u32>,
     pub(crate) n300: Option<u32>,
     pub(crate) n100: Option<u32>,
@@ -173,20 +174,26 @@ impl<'map> OsuPerformance<'map> {
     ///   slider ticks and repeats
     /// - if set on osu!lazer *with* `CL`, this value is the amount of hit
     ///   slider heads, ticks, and repeats
-    pub const fn n_large_ticks(mut self, n_large_ticks: u32) -> Self {
-        self.large_tick_hits = Some(n_large_ticks);
+    pub const fn large_tick_hits(mut self, large_tick_hits: u32) -> Self {
+        self.large_tick_hits = Some(large_tick_hits);
+
+        self
+    }
+
+    /// Specify the amount of "small tick" hits.
+    ///
+    /// Only relevant for osu!lazer scores without slider accuracy.
+    pub const fn small_tick_hits(mut self, small_tick_hits: u32) -> Self {
+        self.small_tick_hits = Some(small_tick_hits);
 
         self
     }
 
     /// Specify the amount of hit slider ends.
     ///
-    /// Only relevant for osu!lazer.
-    ///
-    /// osu! calls this value "slider tail hits" without the classic
-    /// mod and "small tick hits" with the classic mod.
-    pub const fn n_slider_ends(mut self, n_slider_ends: u32) -> Self {
-        self.slider_end_hits = Some(n_slider_ends);
+    /// Only relevant for osu!lazer scores with slider accuracy.
+    pub const fn slider_end_hits(mut self, slider_end_hits: u32) -> Self {
+        self.slider_end_hits = Some(slider_end_hits);
 
         self
     }
@@ -319,6 +326,7 @@ impl<'map> OsuPerformance<'map> {
         let OsuScoreState {
             max_combo,
             large_tick_hits,
+            small_tick_hits,
             slider_end_hits,
             n300,
             n100,
@@ -328,6 +336,7 @@ impl<'map> OsuPerformance<'map> {
 
         self.combo = Some(max_combo);
         self.large_tick_hits = Some(large_tick_hits);
+        self.small_tick_hits = Some(small_tick_hits);
         self.slider_end_hits = Some(slider_end_hits);
         self.n300 = Some(n300);
         self.n100 = Some(n100);
@@ -374,43 +383,44 @@ impl<'map> OsuPerformance<'map> {
         let lazer = self.difficulty.get_lazer();
         let using_classic_slider_acc = self.difficulty.get_mods().no_slider_head_acc(lazer);
 
-        let (origin, slider_end_hits, large_tick_hits) = match (lazer, using_classic_slider_acc) {
-            (false, _) => (OsuScoreOrigin::Stable, 0, 0),
-            (true, false) => {
-                let origin = OsuScoreOrigin::WithSliderAcc {
-                    max_large_ticks: attrs.n_large_ticks,
-                    max_slider_ends: attrs.n_sliders,
-                };
+        let (origin, slider_end_hits, large_tick_hits, small_tick_hits) =
+            match (lazer, using_classic_slider_acc) {
+                (false, _) => (OsuScoreOrigin::Stable, 0, 0, 0),
+                (true, false) => {
+                    let origin = OsuScoreOrigin::WithSliderAcc {
+                        max_large_ticks: attrs.n_large_ticks,
+                        max_slider_ends: attrs.n_sliders,
+                    };
 
-                let slider_end_hits = self
-                    .slider_end_hits
-                    .map_or(attrs.n_sliders, |n| cmp::min(n, attrs.n_sliders));
+                    let slider_end_hits = self
+                        .slider_end_hits
+                        .map_or(attrs.n_sliders, |n| cmp::min(n, attrs.n_sliders));
 
-                let large_tick_hits = self
-                    .large_tick_hits
-                    .map_or(attrs.n_large_ticks, |n| cmp::min(n, attrs.n_large_ticks));
+                    let large_tick_hits = self
+                        .large_tick_hits
+                        .map_or(attrs.n_large_ticks, |n| cmp::min(n, attrs.n_large_ticks));
 
-                (origin, slider_end_hits, large_tick_hits)
-            }
-            (true, true) => {
-                let origin = OsuScoreOrigin::WithoutSliderAcc {
-                    max_large_ticks: attrs.n_sliders + attrs.n_large_ticks,
-                    max_slider_ends: attrs.n_sliders,
-                };
+                    (origin, slider_end_hits, large_tick_hits, 0)
+                }
+                (true, true) => {
+                    let origin = OsuScoreOrigin::WithoutSliderAcc {
+                        max_large_ticks: attrs.n_sliders + attrs.n_large_ticks,
+                        max_small_ticks: attrs.n_sliders,
+                    };
 
-                let slider_end_hits = self
-                    .slider_end_hits
-                    .map_or(attrs.n_sliders, |n| cmp::min(n, attrs.n_sliders));
+                    let small_tick_hits = self
+                        .small_tick_hits
+                        .map_or(attrs.n_sliders, |n| cmp::min(n, attrs.n_sliders));
 
-                let large_tick_hits = self
-                    .large_tick_hits
-                    .map_or(attrs.n_sliders + attrs.n_large_ticks, |n| {
-                        cmp::min(n, attrs.n_sliders + attrs.n_large_ticks)
-                    });
+                    let large_tick_hits = self
+                        .large_tick_hits
+                        .map_or(attrs.n_sliders + attrs.n_large_ticks, |n| {
+                            cmp::min(n, attrs.n_sliders + attrs.n_large_ticks)
+                        });
 
-                (origin, slider_end_hits, large_tick_hits)
-            }
-        };
+                    (origin, 0, large_tick_hits, small_tick_hits)
+                }
+            };
 
         let (slider_acc_value, max_slider_acc_value) = match origin {
             OsuScoreOrigin::Stable => (0, 0),
@@ -423,10 +433,10 @@ impl<'map> OsuPerformance<'map> {
             ),
             OsuScoreOrigin::WithoutSliderAcc {
                 max_large_ticks,
-                max_slider_ends,
+                max_small_ticks,
             } => (
-                30 * large_tick_hits + 10 * slider_end_hits,
-                30 * max_large_ticks + 10 * max_slider_ends,
+                30 * large_tick_hits + 10 * small_tick_hits,
+                30 * max_large_ticks + 10 * max_small_ticks,
             ),
         };
 
@@ -466,6 +476,7 @@ impl<'map> OsuPerformance<'map> {
                             n50: new50,
                             misses,
                             large_tick_hits,
+                            small_tick_hits,
                             slider_end_hits,
                         };
 
@@ -499,6 +510,7 @@ impl<'map> OsuPerformance<'map> {
                             n50: new50,
                             misses,
                             large_tick_hits,
+                            small_tick_hits,
                             slider_end_hits,
                         };
 
@@ -533,6 +545,7 @@ impl<'map> OsuPerformance<'map> {
                             n50,
                             misses,
                             large_tick_hits,
+                            small_tick_hits,
                             slider_end_hits,
                         };
 
@@ -569,6 +582,7 @@ impl<'map> OsuPerformance<'map> {
                                 n50: new50,
                                 misses,
                                 large_tick_hits,
+                                small_tick_hits,
                                 slider_end_hits,
                             };
 
@@ -629,6 +643,7 @@ impl<'map> OsuPerformance<'map> {
         self.combo = Some(max_combo);
         self.slider_end_hits = Some(slider_end_hits);
         self.large_tick_hits = Some(large_tick_hits);
+        self.small_tick_hits = Some(small_tick_hits);
         self.n300 = Some(n300);
         self.n100 = Some(n100);
         self.n50 = Some(n50);
@@ -637,6 +652,7 @@ impl<'map> OsuPerformance<'map> {
         Ok(OsuScoreState {
             max_combo,
             large_tick_hits,
+            small_tick_hits,
             slider_end_hits,
             n300,
             n100,
@@ -700,7 +716,7 @@ impl<'map> OsuPerformance<'map> {
             },
             (true, true) => OsuScoreOrigin::WithoutSliderAcc {
                 max_large_ticks: attrs.n_sliders + attrs.n_large_ticks,
-                max_slider_ends: attrs.n_sliders,
+                max_small_ticks: attrs.n_sliders,
             },
         };
 
@@ -725,6 +741,7 @@ impl<'map> OsuPerformance<'map> {
             acc: None,
             combo: None,
             large_tick_hits: None,
+            small_tick_hits: None,
             slider_end_hits: None,
             n300: None,
             n100: None,
@@ -1122,6 +1139,7 @@ struct NoComboState {
     n50: u32,
     misses: u32,
     large_tick_hits: u32,
+    small_tick_hits: u32,
     slider_end_hits: u32,
 }
 
@@ -1144,13 +1162,13 @@ impl NoComboState {
             }
             OsuScoreOrigin::WithoutSliderAcc {
                 max_large_ticks,
-                max_slider_ends,
+                max_small_ticks,
             } => {
                 let large_tick_hits = self.large_tick_hits.min(max_large_ticks);
-                let slider_end_hits = self.slider_end_hits.min(max_slider_ends);
+                let small_tick_hits = self.small_tick_hits.min(max_small_ticks);
 
-                numerator += 30 * large_tick_hits + 10 * slider_end_hits;
-                denominator += 30 * max_large_ticks + 10 * max_slider_ends;
+                numerator += 30 * large_tick_hits + 10 * small_tick_hits;
+                denominator += 30 * max_large_ticks + 10 * max_small_ticks;
             }
         }
 
@@ -1228,8 +1246,8 @@ mod test {
     ) -> OsuScoreState {
         let misses = cmp::min(misses, N_OBJECTS);
 
-        let (origin, slider_end_hits, large_tick_hits) = match (lazer, classic) {
-            (false, _) => (OsuScoreOrigin::Stable, 0, 0),
+        let (origin, slider_end_hits, large_tick_hits, small_tick_hits) = match (lazer, classic) {
+            (false, _) => (OsuScoreOrigin::Stable, 0, 0, 0),
             (true, false) => {
                 let origin = OsuScoreOrigin::WithSliderAcc {
                     max_large_ticks: N_SLIDER_TICKS,
@@ -1241,21 +1259,21 @@ mod test {
                 let large_tick_hits =
                     large_tick_hits.map_or(N_SLIDER_TICKS, |n| cmp::min(n, N_SLIDER_TICKS));
 
-                (origin, slider_end_hits, large_tick_hits)
+                (origin, slider_end_hits, large_tick_hits, 0)
             }
             (true, true) => {
                 let origin = OsuScoreOrigin::WithoutSliderAcc {
                     max_large_ticks: N_SLIDERS + N_SLIDER_TICKS,
-                    max_slider_ends: N_SLIDERS,
+                    max_small_ticks: N_SLIDERS,
                 };
 
-                let slider_end_hits = slider_end_hits.map_or(N_SLIDERS, |n| cmp::min(n, N_SLIDERS));
+                let small_tick_hits = slider_end_hits.map_or(N_SLIDERS, |n| cmp::min(n, N_SLIDERS));
 
                 let large_tick_hits = large_tick_hits.map_or(N_SLIDERS + N_SLIDER_TICKS, |n| {
                     cmp::min(n, N_SLIDERS + N_SLIDER_TICKS)
                 });
 
-                (origin, slider_end_hits, large_tick_hits)
+                (origin, 0, large_tick_hits, small_tick_hits)
             }
         };
 
@@ -1263,6 +1281,7 @@ mod test {
             misses,
             slider_end_hits,
             large_tick_hits,
+            small_tick_hits,
             ..Default::default()
         };
 
@@ -1304,6 +1323,7 @@ mod test {
                     n50: new50,
                     misses,
                     large_tick_hits,
+                    small_tick_hits,
                     slider_end_hits,
                 };
 
@@ -1383,11 +1403,12 @@ mod test {
             }
 
             if let Some(large_tick_hits) = large_tick_hits {
-                state = state.n_large_ticks(large_tick_hits);
+                state = state.large_tick_hits(large_tick_hits);
             }
 
-            if let Some(n_slider_ends) = slider_end_hits {
-                state = state.n_slider_ends(n_slider_ends);
+            if let Some(slider_end_hits) = slider_end_hits {
+                state = state.slider_end_hits(slider_end_hits);
+                state = state.small_tick_hits(slider_end_hits);
             }
 
             if let Some(n300) = n300 {
@@ -1443,6 +1464,7 @@ mod test {
         let expected = OsuScoreState {
             max_combo: 500,
             large_tick_hits: N_SLIDER_TICKS,
+            small_tick_hits: 0,
             slider_end_hits: N_SLIDERS,
             n300: 300,
             n100: 20,
@@ -1468,6 +1490,7 @@ mod test {
         let expected = OsuScoreState {
             max_combo: 500,
             large_tick_hits: 0,
+            small_tick_hits: 0,
             slider_end_hits: 0,
             n300: 300,
             n100: 289,
@@ -1492,6 +1515,7 @@ mod test {
         let expected = OsuScoreState {
             max_combo: 500,
             large_tick_hits: N_SLIDER_TICKS,
+            small_tick_hits: 0,
             slider_end_hits: N_SLIDERS,
             n300: 0,
             n100: 589,
@@ -1518,6 +1542,7 @@ mod test {
         let expected = OsuScoreState {
             max_combo: 500,
             large_tick_hits: 0,
+            small_tick_hits: 0,
             slider_end_hits: 0,
             n300: 300,
             n100: 50,

--- a/src/osu/performance/mod.rs
+++ b/src/osu/performance/mod.rs
@@ -182,7 +182,8 @@ impl<'map> OsuPerformance<'map> {
 
     /// Specify the amount of "small tick" hits.
     ///
-    /// Only relevant for osu!lazer scores without slider accuracy.
+    /// Only relevant for osu!lazer scores without slider accuracy. In that
+    /// case, this value is the amount of slider tail hits.
     pub const fn small_tick_hits(mut self, small_tick_hits: u32) -> Self {
         self.small_tick_hits = Some(small_tick_hits);
 

--- a/src/osu/score_state.rs
+++ b/src/osu/score_state.rs
@@ -1,5 +1,5 @@
 /// Aggregation for a score's current state.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OsuScoreState {
     /// Maximum combo that the score has had so far. **Not** the maximum
     /// possible combo of the map so far.
@@ -12,7 +12,16 @@ pub struct OsuScoreState {
     ///   slider ticks and repeats
     /// - if set on osu!lazer *with* `CL`, this field is the amount of hit
     ///   slider heads, ticks, and repeats
+    ///
+    /// Only relevant for osu!lazer.
     pub large_tick_hits: u32,
+    /// "Small ticks" hits.
+    ///
+    /// These are essentially the slider end hits for lazer scores without
+    /// slider accuracy.
+    ///
+    /// Only relevant for osu!lazer.
+    pub small_tick_hits: u32,
     /// Amount of successfully hit slider ends.
     ///
     /// Only relevant for osu!lazer.
@@ -33,6 +42,7 @@ impl OsuScoreState {
         Self {
             max_combo: 0,
             large_tick_hits: 0,
+            small_tick_hits: 0,
             slider_end_hits: 0,
             n300: 0,
             n100: 0,
@@ -65,13 +75,13 @@ impl OsuScoreState {
             }
             OsuScoreOrigin::WithoutSliderAcc {
                 max_large_ticks,
-                max_slider_ends,
+                max_small_ticks,
             } => {
                 let large_tick_hits = self.large_tick_hits.min(max_large_ticks);
-                let slider_end_hits = self.slider_end_hits.min(max_slider_ends);
+                let small_tick_hits = self.small_tick_hits.min(max_small_ticks);
 
-                numerator += 30 * large_tick_hits + 10 * slider_end_hits;
-                denominator += 30 * max_large_ticks + 10 * max_slider_ends;
+                numerator += 30 * large_tick_hits + 10 * small_tick_hits;
+                denominator += 30 * max_large_ticks + 10 * max_small_ticks;
             }
         }
 
@@ -102,6 +112,6 @@ pub enum OsuScoreOrigin {
     /// For scores set on osu!lazer without slider accuracy
     WithoutSliderAcc {
         max_large_ticks: u32,
-        max_slider_ends: u32,
+        max_small_ticks: u32,
     },
 }

--- a/src/taiko/performance/mod.rs
+++ b/src/taiko/performance/mod.rs
@@ -364,6 +364,7 @@ impl<'map> TryFrom<OsuPerformance<'map>> for TaikoPerformance<'map> {
             acc,
             combo,
             large_tick_hits: _,
+            small_tick_hits: _,
             slider_end_hits: _,
             n300,
             n100,


### PR DESCRIPTION
If users use the osu! api they're provided score statistics containing slider tail hits and small tick hits. Instead of requiring users to check for themselves which one of the two they need to pass to the `slider_tail_hits` method, there is now a `small_tick_hits` methods so `rosu_pp` can pick the correct value automatically.

There's also breaking changes:
- `OsuPerformance::n_large_ticks` has been renamed to `large_tick_hits`
- `OsuPerformance::n_slider_ends` has been renamed to `slider_end_hits`
- `Performance::n_slider_ends` has been renamed to `slider_end_hits`
- `OsuScoreState` has an additional field `small_tick_hits`
- `ScoreState` has an additional field `osu_small_tick_hits`
- `OsuScoreState` is no longer `Copy`
