### PR TITLE
refactor: slight `GameMods` simplification

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -10,4 +10,5 @@ pub mod hit_object;
 /// Gamemode related types.
 pub mod mode;
 
-pub(crate) mod mods;
+/// Gamemods related types.
+pub mod mods;


### PR DESCRIPTION
Avoid the intermediate type which unnecessarily hid the re-exported types. Instead, re-export the types properly to hopefully make it clearer to users when their `rosu-mods` version mismatches.

Also gives users a bit more control over their mods instances since enum variants are freely accessible.