### PR TITLE
fix!: mania lazer accuracy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rosu-map = { git = "https://github.com/MaxOhn/rosu-map" }
 rosu-mods = { version = "0.3.0" }
 
 [dev-dependencies]
-proptest = "1.4.0"
+proptest = "1.6.0"
 
 [profile.test.package.proptest]
 opt-level = 3

--- a/proptest-regressions/mania/performance/mod.txt
+++ b/proptest-regressions/mania/performance/mod.txt
@@ -20,3 +20,6 @@ cc 0924f546edd96e86ee6163aa08dd6b77fc5a6219be6766a5b5d3b6d0caa80145 # shrinks to
 cc a3c828166cc0a217e7a4e2d3592372209f886b6ea78a3da40664f3201df5a49b # shrinks to acc = 0.0, n320 = Some(0), n300 = Some(66), n200 = None, n100 = None, n50 = None, n_misses = Some(529), best_case = false
 cc 1d15772c531f04fc3c0cc28ce76cf219ce7db950f36d3688bc01714a72fb8e5a # shrinks to acc = 0.0, n320 = None, n300 = None, n200 = None, n100 = None, n50 = None, n_misses = Some(595), best_case = false
 cc d3ee41c1d71505bc965f52f591792539d06b370305428f1f20d798b0c525328d
+cc c52017a8d3f2ecdd36b2d522a8e5f17b7fb7b951a9eb84c8d2537b857f019f47 # shrinks to classic = false, acc = 0.463979922129014, n320 = None, n300 = Some(1), n200 = None, n100 = None, n50 = None, n_misses = Some(384), best_case = false
+cc c7995a555d9fc698d9eb52c3ec30604cae4463c57d7e54abe1af1b823dce3bbd # shrinks to classic = false, acc = 0.3455386317199003, n320 = None, n300 = None, n200 = None, n100 = Some(0), n50 = None, n_misses = None, best_case = true
+cc e6baa2d0e1559edaf17898b9cfea4ad24b1ac0f4a336fa372b9e768e79675d21 # shrinks to classic = false, acc = 0.0, n320 = None, n300 = None, n200 = None, n100 = None, n50 = Some(0), n_misses = None, best_case = true

--- a/src/mania/performance/mod.rs
+++ b/src/mania/performance/mod.rs
@@ -175,8 +175,11 @@ impl<'map> ManiaPerformance<'map> {
     ///
     /// Defaults to `true`.
     ///
-    /// This affects internal hitresult generation because lazer gives two
-    /// hitresults per hold note whereas stable only gives one.
+    /// This affects internal hitresult generation because lazer (without `CL`
+    /// mod) gives two hitresults per hold note whereas stable only gives one.
+    /// It also affect accuracy calculation because stable makes no difference
+    /// between perfect (n320) and great (n300) hitresults but lazer (without
+    /// `CL` mod) rewards slightly more for perfect hitresults.
     pub fn lazer(mut self, lazer: bool) -> Self {
         self.difficulty = self.difficulty.lazer(lazer);
 
@@ -259,27 +262,26 @@ impl<'map> ManiaPerformance<'map> {
             MapOrAttrs::Attrs(ref attrs) => attrs,
         };
 
-        let mut n_objects = cmp::min(self.difficulty.get_passed_objects() as u32, attrs.n_objects);
-
         let priority = self.hitresult_priority;
-
+        let mut n_objects = cmp::min(self.difficulty.get_passed_objects() as u32, attrs.n_objects);
         let misses = self.misses.map_or(0, |n| cmp::min(n, n_objects));
+        let classic = !self.difficulty.get_lazer() || self.difficulty.get_mods().cl();
 
-        if self.difficulty.get_lazer() {
+        if !classic {
             n_objects += attrs.n_hold_notes;
         }
 
         let n_remaining = n_objects - misses;
 
-        let mut n320 = self.n320.map_or(0, |n| cmp::min(n, n_remaining));
-        let mut n300 = self.n300.map_or(0, |n| cmp::min(n, n_remaining));
-        let mut n200 = self.n200.map_or(0, |n| cmp::min(n, n_remaining));
-        let mut n100 = self.n100.map_or(0, |n| cmp::min(n, n_remaining));
-        let mut n50 = self.n50.map_or(0, |n| cmp::min(n, n_remaining));
+        let min_remaining = |n: u32| cmp::min(n, n_remaining);
+
+        let mut n320 = self.n320.map_or(0, min_remaining);
+        let mut n300 = self.n300.map_or(0, min_remaining);
+        let mut n200 = self.n200.map_or(0, min_remaining);
+        let mut n100 = self.n100.map_or(0, min_remaining);
+        let mut n50 = self.n50.map_or(0, min_remaining);
 
         if let Some(acc) = self.acc {
-            let target_total = acc * f64::from(6 * n_objects);
-
             match (self.n320, self.n300, self.n200, self.n100, self.n50) {
                 // All hitresults given
                 (Some(_), Some(_), Some(_), Some(_), Some(_)) => {
@@ -293,456 +295,274 @@ impl<'map> ManiaPerformance<'map> {
                 }
 
                 // All but one hitresults given
-                (None, Some(_), Some(_), Some(_), Some(_)) => {
-                    n320 = n_objects.saturating_sub(n300 + n200 + n100 + n50 + misses);
-                }
-                (Some(_), None, Some(_), Some(_), Some(_)) => {
-                    n300 = n_objects.saturating_sub(n320 + n200 + n100 + n50 + misses);
-                }
-                (Some(_), Some(_), None, Some(_), Some(_)) => {
-                    n200 = n_objects.saturating_sub(n320 + n300 + n100 + n50 + misses);
-                }
-                (Some(_), Some(_), Some(_), None, Some(_)) => {
-                    n100 = n_objects.saturating_sub(n320 + n300 + n200 + n50 + misses);
-                }
-                (Some(_), Some(_), Some(_), Some(_), None) => {
-                    n50 = n_objects.saturating_sub(n320 + n300 + n200 + n100 + misses);
-                }
+                (None, Some(_), Some(_), Some(_), Some(_)) => n320 = n_remaining,
+                (Some(_), None, Some(_), Some(_), Some(_)) => n300 = n_remaining,
+                (Some(_), Some(_), None, Some(_), Some(_)) => n200 = n_remaining,
+                (Some(_), Some(_), Some(_), None, Some(_)) => n100 = n_remaining,
+                (Some(_), Some(_), Some(_), Some(_), None) => n50 = n_remaining,
 
-                // n200, n100, and n50 given
-                (None, None, Some(_), Some(_), Some(_)) => {
-                    let n_remaining =
-                        n_objects.saturating_sub(n320 + n300 + n200 + n100 + n50 + misses);
+                // At least two hitresults are unknown
+                _ => {
+                    let target = acc * f64::from(if classic { 60 } else { 61 } * n_objects);
 
-                    match priority {
-                        HitResultPriority::BestCase => n320 = n_remaining,
-                        HitResultPriority::WorstCase => n300 = n_remaining,
-                    }
-                }
-
-                // n100 and n50 given
-                (.., None, Some(_), Some(_)) => {
-                    let mut best_dist = f64::INFINITY;
-                    let mut n3x0 = n_objects.saturating_sub(n320 + n300 + n100 + n50 + misses);
-
-                    let raw_n3x0 = (target_total - f64::from(4 * n_remaining)
-                        + f64::from(2 * n100 + 3 * n50))
-                        / 2.0;
-                    let min_n3x0 = cmp::min(
-                        raw_n3x0.floor() as u32,
-                        n_remaining.saturating_sub(n100 + n50),
-                    );
-                    let max_n3x0 = cmp::min(
-                        raw_n3x0.ceil() as u32,
-                        n_remaining.saturating_sub(n100 + n50),
-                    );
-
-                    let (min_n3x0, max_n3x0) = match (self.n320, self.n300) {
-                        (Some(_), Some(_)) => (n320 + n300, n320 + n300),
-                        (Some(_), None) => (cmp::max(min_n3x0, n320), cmp::max(max_n3x0, n320)),
-                        (None, Some(_)) => (cmp::max(min_n3x0, n300), cmp::max(max_n3x0, n300)),
-                        (None, None) => (min_n3x0, max_n3x0),
+                    let mut best = ManiaScoreState {
+                        n320,
+                        n300,
+                        n200,
+                        n100,
+                        n50: n_remaining.saturating_sub(n320 + n300 + n200 + n100),
+                        misses,
                     };
 
-                    for new3x0 in min_n3x0..=max_n3x0 {
-                        let new200 = n_remaining.saturating_sub(new3x0 + n100 + n50);
-                        let curr_dist =
-                            (acc - accuracy(new3x0, 0, new200, n100, n50, misses)).abs();
-
-                        if curr_dist < best_dist {
-                            best_dist = curr_dist;
-                            n3x0 = new3x0;
-                            n200 = new200;
-                        }
-                    }
-
-                    match (self.n320, self.n300) {
-                        (None, None) => match priority {
-                            HitResultPriority::BestCase => n320 = n3x0,
-                            HitResultPriority::WorstCase => n300 = n3x0,
-                        },
-                        (Some(_), None) => n300 = n3x0 - n320,
-                        (None, Some(_)) => n320 = n3x0 - n300,
-                        _ => {}
-                    }
-                }
-
-                // n200 and n50 given
-                (.., Some(_), None, Some(_)) => {
                     let mut best_dist = f64::INFINITY;
-                    let mut n3x0 = n_objects.saturating_sub(n320 + n300 + n200 + n50 + misses);
 
-                    let raw_n3x0 = (target_total - f64::from(2 * (n_remaining + n200) - n50)) / 4.0;
-                    let min_n3x0 = cmp::min(
-                        raw_n3x0.floor() as u32,
-                        n_remaining.saturating_sub(n200 + n50),
-                    );
-                    let max_n3x0 = cmp::min(
-                        raw_n3x0.ceil() as u32,
-                        n_remaining.saturating_sub(n200 + n50),
-                    );
+                    let remaining = n_remaining.saturating_sub(n300 + n200 + n100 + n50);
 
-                    let (min_n3x0, max_n3x0) = match (self.n320, self.n300) {
-                        (Some(_), Some(_)) => (n320 + n300, n320 + n300),
-                        (Some(_), None) => (cmp::max(min_n3x0, n320), cmp::max(max_n3x0, n320)),
-                        (None, Some(_)) => (cmp::max(min_n3x0, n300), cmp::max(max_n3x0, n300)),
-                        (None, None) => (min_n3x0, max_n3x0),
-                    };
-
-                    for new3x0 in min_n3x0..=max_n3x0 {
-                        let new100 = n_remaining.saturating_sub(new3x0 + n200 + n50);
-                        let curr_dist =
-                            (acc - accuracy(new3x0, 0, n200, new100, n50, misses)).abs();
-
-                        if curr_dist < best_dist {
-                            best_dist = curr_dist;
-                            n3x0 = new3x0;
-                            n100 = new100;
-                        }
-                    }
-
-                    match (self.n320, self.n300) {
-                        (None, None) => match priority {
-                            HitResultPriority::BestCase => n320 = n3x0,
-                            HitResultPriority::WorstCase => n300 = n3x0,
-                        },
-                        (Some(_), None) => n300 = n3x0 - n320,
-                        (None, Some(_)) => n320 = n3x0 - n300,
-                        _ => {}
-                    }
-                }
-
-                // n200 and n100 given
-                (.., Some(_), Some(_), None) => {
-                    let mut best_dist = f64::INFINITY;
-                    let mut n3x0 = n_objects.saturating_sub(n320 + n300 + n200 + n100 + misses);
-
-                    let raw_n3x0 = (target_total - f64::from(n_remaining + 3 * n200 + n100)) / 5.0;
-                    let min_n3x0 = cmp::min(
-                        raw_n3x0.floor() as u32,
-                        n_remaining.saturating_sub(n200 + n100),
-                    );
-                    let max_n3x0 = cmp::min(
-                        raw_n3x0.ceil() as u32,
-                        n_remaining.saturating_sub(n200 + n100),
+                    let mut min_n320 = cmp::min(
+                        (if classic {
+                            ((target - f64::from(40 * n_remaining)
+                                + f64::from(20 * n100 + 30 * n50))
+                                / 20.0)
+                                - f64::from(n300)
+                        } else {
+                            target - f64::from(60 * n_remaining)
+                                + f64::from(20 * n200 + 40 * n100 + 50 * n50)
+                        })
+                        .floor() as u32,
+                        remaining,
                     );
 
-                    let (min_n3x0, max_n3x0) = match (self.n320, self.n300) {
-                        (Some(_), Some(_)) => (n320 + n300, n320 + n300),
-                        (Some(_), None) => (cmp::max(min_n3x0, n320), cmp::max(max_n3x0, n320)),
-                        (None, Some(_)) => (cmp::max(min_n3x0, n300), cmp::max(max_n3x0, n300)),
-                        (None, None) => (min_n3x0, max_n3x0),
-                    };
-
-                    for new3x0 in min_n3x0..=max_n3x0 {
-                        let new50 = n_remaining.saturating_sub(new3x0 + n200 + n100);
-                        let curr_dist =
-                            (acc - accuracy(new3x0, 0, n200, n100, new50, misses)).abs();
-
-                        if curr_dist < best_dist {
-                            best_dist = curr_dist;
-                            n3x0 = new3x0;
-                            n50 = new50;
-                        }
-                    }
-
-                    match (self.n320, self.n300) {
-                        (None, None) => match priority {
-                            HitResultPriority::BestCase => n320 = n3x0,
-                            HitResultPriority::WorstCase => n300 = n3x0,
-                        },
-                        (Some(_), None) => n300 = n3x0 - n320,
-                        (None, Some(_)) => n320 = n3x0 - n300,
-                        _ => {}
-                    }
-                }
-
-                // n200 given
-                (.., Some(_), None, None) => {
-                    let mut best_dist = f64::INFINITY;
-                    let mut n3x0 = n_objects.saturating_sub(n320 + n300 + n200 + misses);
-
-                    let min_n3x0 = cmp::min(
-                        ((target_total - f64::from(2 * (n_remaining + n200))) / 4.0).floor() as u32,
-                        n_remaining - n200,
+                    let mut max_n320 = cmp::min(
+                        ((target - f64::from(10 * n_remaining + 50 * n300 + 30 * n200 + 10 * n100))
+                            / if classic { 50.0 } else { 51.0 })
+                        .ceil() as u32,
+                        remaining,
                     );
 
-                    let max_n3x0 = cmp::min(
-                        ((target_total - f64::from(n_remaining + 3 * n200)) / 5.0).ceil() as u32,
-                        n_remaining - n200,
-                    );
-
-                    let (min_n3x0, max_n3x0) = match (self.n320, self.n300) {
-                        (Some(_), Some(_)) => (
-                            cmp::min(n_remaining, n320 + n300),
-                            cmp::min(n_remaining, n320 + n300),
-                        ),
-                        (Some(_), None) => (cmp::max(min_n3x0, n320), cmp::max(max_n3x0, n320)),
-                        (None, Some(_)) => (cmp::max(min_n3x0, n300), cmp::max(max_n3x0, n300)),
-                        (None, None) => (min_n3x0, max_n3x0),
-                    };
-
-                    for new3x0 in min_n3x0..=max_n3x0 {
-                        let raw_n100 =
-                            target_total - f64::from(n_remaining + 5 * new3x0 + 3 * n200);
-                        let min_n100 = cmp::min(
-                            raw_n100.floor() as u32,
-                            n_remaining.saturating_sub(new3x0 + n200),
-                        );
-                        let max_n100 = cmp::min(
-                            raw_n100.ceil() as u32,
-                            n_remaining.saturating_sub(new3x0 + n200),
-                        );
-
-                        for new100 in min_n100..=max_n100 {
-                            let new50 = n_remaining.saturating_sub(new3x0 + n200 + new100);
-                            let curr_dist =
-                                (acc - accuracy(new3x0, 0, n200, new100, new50, misses)).abs();
-
-                            if curr_dist < best_dist {
-                                best_dist = curr_dist;
-                                n3x0 = new3x0;
-                                n100 = new100;
-                                n50 = new50;
-                            }
-                        }
+                    if let Some(n320) = self.n320 {
+                        min_n320 = min_remaining(n320);
+                        max_n320 = min_remaining(n320);
                     }
 
-                    match (self.n320, self.n300) {
-                        (None, None) => match priority {
-                            HitResultPriority::BestCase => n320 = n3x0,
-                            HitResultPriority::WorstCase => n300 = n3x0,
-                        },
-                        (Some(_), None) => n300 = n3x0 - n320,
-                        (None, Some(_)) => n320 = n3x0 - n300,
-                        _ => {}
-                    }
-                }
+                    for n320 in min_n320..=max_n320 {
+                        let remaining = n_remaining.saturating_sub(n320 + n200 + n100 + n50);
 
-                // n100 given
-                (.., None, Some(_), None) => {
-                    let mut best_dist = f64::INFINITY;
-                    let mut n3x0 = n_objects.saturating_sub(n320 + n300 + n100 + misses);
+                        let mut min_n300 = cmp::min(
+                            (if classic && self.n320.is_none() {
+                                // n320 and n300 have the same value so we
+                                // generate them all via n320 and shift them
+                                // afterwards if necessary
+                                0.0
+                            } else {
+                                let n320_weight = if classic { 20 } else { 21 };
 
-                    let min_n3x0 = cmp::min(
-                        (acc * f64::from(3 * n_remaining) - f64::from(2 * n_remaining - n100))
+                                (target - f64::from(40 * n_remaining + n320_weight * n320)
+                                    + f64::from(20 * n100 + 30 * n50))
+                                    / 20.0
+                            })
                             .floor() as u32,
-                        n_remaining - n100,
-                    );
-
-                    let max_n3x0 = cmp::min(
-                        ((target_total - f64::from(n_remaining + n100)) / 5.0).ceil() as u32,
-                        n_remaining - n100,
-                    );
-
-                    let (min_n3x0, max_n3x0) = match (self.n320, self.n300) {
-                        (Some(_), Some(_)) => (
-                            cmp::min(n_remaining, n320 + n300),
-                            cmp::min(n_remaining, n320 + n300),
-                        ),
-                        (Some(_), None) => (cmp::max(min_n3x0, n320), cmp::max(max_n3x0, n320)),
-                        (None, Some(_)) => (cmp::max(min_n3x0, n300), cmp::max(max_n3x0, n300)),
-                        (None, None) => (min_n3x0, max_n3x0),
-                    };
-
-                    for new3x0 in min_n3x0..=max_n3x0 {
-                        let raw_n200 =
-                            (target_total - f64::from(n_remaining + 5 * new3x0 + n100)) / 3.0;
-                        let min_n200 = cmp::min(
-                            raw_n200.floor() as u32,
-                            n_remaining.saturating_sub(new3x0 + n100),
-                        );
-                        let max_n200 = cmp::min(
-                            raw_n200.ceil() as u32,
-                            n_remaining.saturating_sub(new3x0 + n100),
+                            remaining,
                         );
 
-                        for new200 in min_n200..=max_n200 {
-                            let new50 = n_remaining.saturating_sub(new3x0 + new200 + n100);
-                            let curr_dist =
-                                (acc - accuracy(new3x0, 0, new200, n100, new50, misses)).abs();
+                        let mut max_n300 = cmp::min(
+                            (if classic && self.n320.is_none() {
+                                0.0
+                            } else {
+                                let n320_weight = if classic { 50 } else { 51 };
 
-                            if curr_dist < best_dist {
-                                best_dist = curr_dist;
-                                n3x0 = new3x0;
-                                n200 = new200;
-                                n50 = new50;
-                            }
-                        }
-                    }
-
-                    match (self.n320, self.n300) {
-                        (None, None) => match priority {
-                            HitResultPriority::BestCase => n320 = n3x0,
-                            HitResultPriority::WorstCase => n300 = n3x0,
-                        },
-                        (Some(_), None) => n300 = n3x0 - n320,
-                        (None, Some(_)) => n320 = n3x0 - n300,
-                        _ => {}
-                    }
-                }
-
-                // n50 given
-                (.., None, None, Some(_)) => {
-                    let mut best_dist = f64::INFINITY;
-                    let mut n3x0 = n_objects.saturating_sub(n320 + n300 + n50 + misses);
-
-                    let min_n3x0 = cmp::min(
-                        ((target_total - f64::from(4 * n_remaining - 3 * n50)) / 2.0).floor()
-                            as u32,
-                        n_remaining - n50,
-                    );
-
-                    let max_n3x0 = cmp::min(
-                        ((target_total - f64::from(2 * n_remaining - n50)) / 4.0).ceil() as u32,
-                        n_remaining - n50,
-                    );
-
-                    let (min_n3x0, max_n3x0) = match (self.n320, self.n300) {
-                        (Some(_), Some(_)) => (
-                            cmp::min(n_remaining, n320 + n300),
-                            cmp::min(n_remaining, n320 + n300),
-                        ),
-                        (Some(_), None) => (cmp::max(min_n3x0, n320), cmp::max(max_n3x0, n320)),
-                        (None, Some(_)) => (cmp::max(min_n3x0, n300), cmp::max(max_n3x0, n300)),
-                        (None, None) => (min_n3x0, max_n3x0),
-                    };
-
-                    for new3x0 in min_n3x0..=max_n3x0 {
-                        let raw_n200 = (target_total - f64::from(2 * n_remaining + 4 * new3x0)
-                            + f64::from(n50))
-                            / 2.0;
-                        let min_n200 = cmp::min(
-                            raw_n200.floor() as u32,
-                            n_remaining.saturating_sub(new3x0 + n50),
-                        );
-                        let max_n200 = cmp::min(
-                            raw_n200.ceil() as u32,
-                            n_remaining.saturating_sub(new3x0 + n50),
-                        );
-
-                        for new200 in min_n200..=max_n200 {
-                            let new100 = n_remaining.saturating_sub(new3x0 + new200 + n50);
-                            let curr_dist =
-                                (acc - accuracy(new3x0, 0, new200, new100, n50, misses)).abs();
-
-                            if curr_dist < best_dist {
-                                best_dist = curr_dist;
-                                n3x0 = new3x0;
-                                n200 = new200;
-                                n100 = new100;
-                            }
-                        }
-                    }
-
-                    match (self.n320, self.n300) {
-                        (None, None) => match priority {
-                            HitResultPriority::BestCase => n320 = n3x0,
-                            HitResultPriority::WorstCase => n300 = n3x0,
-                        },
-                        (Some(_), None) => n300 = n3x0 - n320,
-                        (None, Some(_)) => n320 = n3x0 - n300,
-                        _ => {}
-                    }
-
-                    if self.n320.is_none() {
-                        if let HitResultPriority::BestCase = priority {
-                            // Distribute n200 onto n320 and n100
-                            let n = n200 / 2;
-                            n320 += n;
-                            n200 -= 2 * n;
-                            n100 += n;
-                        }
-                    }
-                }
-
-                // Neither n200, n100, nor n50 given
-                (.., None, None, None) => {
-                    let mut best_dist = f64::INFINITY;
-                    let mut n3x0 = n_objects.saturating_sub(n320 + n300 + n200 + n100 + misses);
-
-                    let min_n3x0 = cmp::min(
-                        ((target_total - f64::from(4 * n_remaining)) / 5.0).floor() as u32,
-                        n_remaining,
-                    );
-
-                    let max_n3x0 = cmp::min(
-                        ((target_total - f64::from(n_remaining)) / 5.0)
-                            .min(acc * f64::from(3 * n_objects) - f64::from(n_remaining))
+                                (target
+                                    - f64::from(
+                                        10 * n_remaining
+                                            + n320_weight * n320
+                                            + 30 * n200
+                                            + 10 * n100,
+                                    ))
+                                    / 50.0
+                            })
                             .ceil() as u32,
-                        n_remaining,
-                    );
-
-                    let (min_n3x0, max_n3x0) = match (self.n320, self.n300) {
-                        (Some(_), Some(_)) => (
-                            cmp::min(n_remaining, n320 + n300),
-                            cmp::min(n_remaining, n320 + n300),
-                        ),
-                        (Some(_), None) => (cmp::max(min_n3x0, n320), cmp::max(max_n3x0, n320)),
-                        (None, Some(_)) => (cmp::max(min_n3x0, n300), cmp::max(max_n3x0, n300)),
-                        (None, None) => (min_n3x0, max_n3x0),
-                    };
-
-                    for new3x0 in min_n3x0..=max_n3x0 {
-                        let min_n200 = cmp::min(
-                            (acc * f64::from(3 * n_objects) - f64::from(n_remaining + 2 * new3x0))
-                                .floor() as u32,
-                            n_remaining - new3x0,
+                            remaining,
                         );
 
-                        let max_n200 = cmp::min(
-                            ((target_total - f64::from(n_remaining + 5 * new3x0)) / 3.0).ceil()
-                                as u32,
-                            n_remaining - new3x0,
-                        );
+                        if let Some(n300) = self.n300 {
+                            min_n300 = min_remaining(n300);
+                            max_n300 = min_remaining(n300);
+                        }
 
-                        for new200 in min_n200..=max_n200 {
-                            let raw_n100 =
-                                target_total - f64::from(n_remaining + 5 * new3x0 + 3 * new200);
-                            let min_n100 =
-                                cmp::min(raw_n100.floor() as u32, n_remaining - (new3x0 + new200));
-                            let max_n100 =
-                                cmp::min(raw_n100.ceil() as u32, n_remaining - (new3x0 + new200));
+                        for n300 in min_n300..=max_n300 {
+                            let remaining = n_remaining.saturating_sub(n320 + n300 + n100 + n50);
 
-                            for new100 in min_n100..=max_n100 {
-                                let new50 = n_remaining - new3x0 - new200 - new100;
-                                let curr_acc = accuracy(new3x0, 0, new200, new100, new50, misses);
-                                let curr_dist = (acc - curr_acc).abs();
+                            let n320_weight = if classic { 50 } else { 51 };
 
-                                if curr_dist < best_dist {
-                                    best_dist = curr_dist;
-                                    n3x0 = new3x0;
-                                    n200 = new200;
-                                    n100 = new100;
-                                    n50 = new50;
+                            let mut min_n200 = cmp::min(
+                                ((target
+                                    - f64::from(20 * n_remaining + n320_weight * n320 + 50 * n300)
+                                    + f64::from(10 * n50))
+                                    / 30.0)
+                                    .floor() as u32,
+                                remaining,
+                            );
+
+                            let mut max_n200 = cmp::min(
+                                ((target
+                                    - f64::from(
+                                        10 * n_remaining
+                                            + n320_weight * n320
+                                            + 50 * n300
+                                            + 10 * n100,
+                                    ))
+                                    / 30.0)
+                                    .ceil() as u32,
+                                remaining,
+                            );
+
+                            if let Some(n200) = self.n200 {
+                                min_n200 = min_remaining(n200);
+                                max_n200 = min_remaining(n200);
+                            }
+
+                            for n200 in min_n200..=max_n200 {
+                                let n100s = if let Some(n100) = self.n100 {
+                                    [min_remaining(n100), min_remaining(n100)]
+                                } else {
+                                    let remaining =
+                                        n_remaining.saturating_sub(n320 + n300 + n200 + n50);
+
+                                    let n100_raw = if self.n50.is_some() {
+                                        let n320_weight = if classic { 41 } else { 42 };
+
+                                        target
+                                            - f64::from(
+                                                19 * n_remaining
+                                                    + n320_weight * n320
+                                                    + 41 * n300
+                                                    + 21 * n200,
+                                            )
+                                            + f64::from(9 * n50)
+                                    } else {
+                                        let n320_weight = if classic { 50 } else { 51 };
+
+                                        (target
+                                            - f64::from(
+                                                10 * n_remaining
+                                                    + n320_weight * n320
+                                                    + 50 * n300
+                                                    + 30 * n200,
+                                            ))
+                                            / 10.0
+                                    };
+
+                                    let min = cmp::min(n100_raw.floor() as u32, remaining);
+                                    let max = cmp::min(n100_raw.ceil() as u32, remaining);
+
+                                    [min, max]
+                                };
+
+                                for n100 in n100s {
+                                    let n50 = if let Some(n50) = self.n50 {
+                                        min_remaining(n50)
+                                    } else {
+                                        n_remaining.saturating_sub(n320 + n300 + n200 + n100)
+                                    };
+
+                                    let mut curr = ManiaScoreState {
+                                        n320,
+                                        n300,
+                                        n200,
+                                        n100,
+                                        n50,
+                                        misses,
+                                    };
+
+                                    if curr.total_hits() < n_objects {
+                                        let remaining = n_objects - curr.total_hits();
+
+                                        match (self.n50, self.n100, self.n200, self.n300, self.n320)
+                                        {
+                                            (None, ..) => curr.n50 += remaining,
+                                            (_, None, ..) => curr.n100 += remaining,
+                                            (_, _, None, ..) => curr.n200 += remaining,
+                                            (.., None, _) => curr.n300 += remaining,
+                                            (.., None) => curr.n320 += remaining,
+                                            _ => curr.n50 += remaining,
+                                        }
+                                    }
+
+                                    let curr_acc = curr.accuracy(classic);
+                                    let curr_dist = (acc - curr_acc).abs();
+
+                                    if curr_dist < best_dist {
+                                        best_dist = curr_dist;
+                                        best = curr;
+                                    }
                                 }
                             }
                         }
                     }
 
-                    match (self.n320, self.n300) {
-                        (None, None) => match priority {
-                            HitResultPriority::BestCase => n320 = n3x0,
-                            HitResultPriority::WorstCase => n300 = n3x0,
-                        },
-                        (Some(_), None) => n300 = n3x0 - n320,
-                        (None, Some(_)) => n320 = n3x0 - n300,
-                        _ => {}
-                    }
+                    // Only n320 have an increased effect on performance
+                    // calculation so we adjust them based on priority
+                    if classic && self.n320.is_none() {
+                        // The logic below only operates on n320 and not n300
+                        // so we shift them here and let the logic below do
+                        // its thing
+                        if self.n300.is_none() {
+                            best.n320 += best.n300;
+                            best.n300 = 0;
+                        }
 
-                    if self.n320.is_none() {
-                        if let HitResultPriority::BestCase = priority {
-                            // Distribute n200 onto n320 and n100
-                            let n = n200 / 2;
-                            n320 += n;
-                            n200 -= 2 * n;
-                            n100 += n;
+                        match priority {
+                            HitResultPriority::BestCase => {
+                                if self.n100.is_none() && self.n200.is_none() {
+                                    let n = best.n200 / 2;
+                                    best.n320 += n;
+                                    best.n200 -= 2 * n;
+                                    best.n100 += n;
+                                }
+
+                                if self.n50.is_none() && self.n200.is_none() {
+                                    let n = best.n200 / 5;
+                                    best.n320 += n * 3;
+                                    best.n200 -= n * 5;
+                                    best.n50 += n * 2;
+                                }
+
+                                if self.n300.is_none() {
+                                    best.n320 += best.n300;
+                                    best.n300 = 0;
+                                }
+                            }
+                            HitResultPriority::WorstCase => {
+                                if self.n100.is_none() && self.n200.is_none() {
+                                    let n = cmp::min(best.n320, best.n100);
+                                    best.n320 -= n;
+                                    best.n200 += 2 * n;
+                                    best.n100 -= n;
+                                }
+
+                                if self.n50.is_none() && self.n200.is_none() {
+                                    let n = cmp::min(best.n320 / 3, best.n50 / 2);
+                                    best.n320 -= n * 3;
+                                    best.n200 += n * 5;
+                                    best.n50 -= n * 2;
+                                }
+
+                                if self.n300.is_none() {
+                                    best.n300 += best.n320;
+                                    best.n320 = 0;
+                                }
+                            }
                         }
                     }
+
+                    n320 = best.n320;
+                    n300 = best.n300;
+                    n200 = best.n200;
+                    n100 = best.n100;
+                    n50 = best.n50;
                 }
             }
         } else {
-            let remaining = n_objects.saturating_sub(n320 + n300 + n200 + n100 + n50 + misses);
+            let remaining = n_remaining.saturating_sub(n320 + n300 + n200 + n100 + n50);
 
             match priority {
                 HitResultPriority::BestCase => {
@@ -869,19 +689,16 @@ impl<'map, T: IntoModePerformance<'map, Mania>> From<T> for ManiaPerformance<'ma
     }
 }
 
-fn accuracy(n320: u32, n300: u32, n200: u32, n100: u32, n50: u32, misses: u32) -> f64 {
-    let numerator = 6 * (n320 + n300) + 4 * n200 + 2 * n100 + n50;
-    let denominator = 6 * (n320 + n300 + n200 + n100 + n50 + misses);
-
-    f64::from(numerator) / f64::from(denominator)
-}
-
 #[cfg(test)]
 mod tests {
-    use std::{cmp::Ordering, sync::OnceLock};
+    use std::{cmp::Ordering, sync::OnceLock, time::Instant};
 
-    use proptest::prelude::*;
+    use proptest::{
+        prelude::*,
+        test_runner::{RngAlgorithm, TestRng},
+    };
     use rosu_map::section::general::GameMode;
+    use rosu_mods::GameMod;
 
     use crate::{
         any::{DifficultyAttributes, PerformanceAttributes},
@@ -918,6 +735,19 @@ mod tests {
             .to_owned()
     }
 
+    /// Creates a [`rosu_mods::GameMods`] instance and inserts `CL` if `classic`
+    /// is true.
+    fn mods(classic: bool) -> rosu_mods::GameMods {
+        if classic {
+            let mut mods = rosu_mods::GameMods::new();
+            mods.insert(GameMod::ClassicMania(Default::default()));
+
+            mods
+        } else {
+            rosu_mods::GameMods::new()
+        }
+    }
+
     /// Checks most remaining hitresult combinations w.r.t. the given parameters
     /// and returns the [`ManiaScoreState`] that matches `acc` the best.
     ///
@@ -925,7 +755,7 @@ mod tests {
     /// that it doesn't run unreasonably long.
     #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
     fn brute_force_best(
-        lazer: bool,
+        classic: bool,
         acc: f64,
         n320: Option<u32>,
         n300: Option<u32>,
@@ -945,12 +775,6 @@ mod tests {
         let mut best_dist = f64::INFINITY;
         let mut best_custom_acc = 0.0;
 
-        let mut n_remaining = N_OBJECTS - misses;
-
-        if lazer {
-            n_remaining += N_HOLD_NOTES;
-        }
-
         let multiple_given = (usize::from(n320.is_some())
             + usize::from(n300.is_some())
             + usize::from(n200.is_some())
@@ -960,118 +784,208 @@ mod tests {
 
         let mut n_objects = N_OBJECTS;
 
-        if lazer {
+        if !classic {
             n_objects += N_HOLD_NOTES;
         }
 
-        let max_left = n_objects
-            .saturating_sub(n200.unwrap_or(0) + n100.unwrap_or(0) + n50.unwrap_or(0) + misses);
+        let n_remaining = n_objects - misses;
 
-        let min_n3x0 = cmp::min(
-            max_left,
-            (acc * f64::from(3 * n_objects) - f64::from(2 * n_remaining)).floor() as u32,
+        let target = acc * f64::from(if classic { 60 } else { 61 } * n_objects);
+
+        let max_left = n_objects.saturating_sub(
+            if classic { 0 } else { n300.unwrap_or(0) }
+                + n200.unwrap_or(0)
+                + n100.unwrap_or(0)
+                + n50.unwrap_or(0)
+                + misses,
         );
 
-        let max_n3x0 = cmp::min(
+        let min_n320 = cmp::min(
             max_left,
-            ((acc * f64::from(6 * n_objects) - f64::from(n_remaining)) / 5.0).ceil() as u32,
+            if classic {
+                (target - f64::from(40 * n_remaining)) / 20.0
+            } else {
+                target - f64::from(60 * n_remaining)
+            }
+            .floor() as u32,
         );
 
-        let (min_n3x0, max_n3x0) = match (n320, n300) {
+        let max_n320 = cmp::min(
+            max_left,
+            ((target - f64::from(10 * n_remaining)) / if classic { 50.0 } else { 51.0 }).ceil()
+                as u32,
+        );
+
+        let (min_n320, max_n320) = match (n320, n300) {
+            (Some(n320), _) if !classic => {
+                (cmp::min(n_remaining, n320), cmp::min(n_remaining, n320))
+            }
+            (None, _) if !classic => (min_n320, max_n320),
             (Some(n320), Some(n300)) => (
                 cmp::min(n_remaining, n320 + n300),
                 cmp::min(n_remaining, n320 + n300),
             ),
             (Some(n320), None) => (
-                cmp::max(cmp::min(n_remaining, n320), min_n3x0),
-                cmp::max(max_n3x0, cmp::min(n320, n_remaining)),
+                cmp::max(cmp::min(n_remaining, n320), min_n320),
+                cmp::max(max_n320, cmp::min(n320, n_remaining)),
             ),
             (None, Some(n300)) => (
-                cmp::max(cmp::min(n_remaining, n300), min_n3x0),
-                cmp::max(max_n3x0, cmp::min(n300, n_remaining)),
+                cmp::max(cmp::min(n_remaining, n300), min_n320),
+                cmp::max(max_n320, cmp::min(n300, n_remaining)),
             ),
-            (None, None) => (min_n3x0, max_n3x0),
+            (None, None) => (min_n320, max_n320),
         };
 
-        for new3x0 in min_n3x0..=max_n3x0 {
-            let max_left =
-                n_remaining.saturating_sub(new3x0 + n100.unwrap_or(0) + n50.unwrap_or(0));
+        let mut n300_iters = 0;
+        let mut n300_skips = 0;
 
-            let (min_n200, max_n200) = match (n200, n100, n50) {
-                (Some(n200), ..) if multiple_given => {
-                    (cmp::min(n_remaining, n200), cmp::min(n_remaining, n200))
+        for new320 in min_n320..=max_n320 {
+            let max_left = n_remaining
+                .saturating_sub(new320 + n200.unwrap_or(0) + n100.unwrap_or(0) + n50.unwrap_or(0));
+
+            let (min_n300, max_n300) = match n300 {
+                _ if classic => (0, 0),
+                Some(n300) if multiple_given => {
+                    (cmp::min(n_remaining, n300), cmp::min(n_remaining, n300))
                 }
-                (Some(n200), ..) => (cmp::min(max_left, n200), cmp::min(max_left, n200)),
-                (None, Some(_), Some(_)) => (max_left, max_left),
-                _ => (0, max_left),
+                Some(n300) => (cmp::min(max_left, n300), cmp::min(max_left, n300)),
+                None if n200.and(n100).and(n50).is_some() => (max_left, max_left),
+                None => (0, max_left),
             };
 
-            for new200 in min_n200..=max_n200 {
-                let max_left = n_remaining.saturating_sub(new3x0 + new200 + n50.unwrap_or(0));
+            for new300 in min_n300..=max_n300 {
+                let max_left = n_remaining
+                    .saturating_sub(new320 + new300 + n100.unwrap_or(0) + n50.unwrap_or(0));
 
-                let (min_n100, max_n100) = match (n100, n50) {
-                    (Some(n100), _) if multiple_given => {
-                        (cmp::min(n_remaining, n100), cmp::min(n_remaining, n100))
-                    }
-                    (Some(n100), _) => (cmp::min(max_left, n100), cmp::min(max_left, n100)),
-                    (None, Some(_)) => (max_left, max_left),
-                    (None, None) => (0, max_left),
+                let min_state = ManiaScoreState {
+                    n320: new320,
+                    n300: new300,
+                    n200: n200.unwrap_or(max_left.saturating_sub(
+                        n100.unwrap_or(max_left.saturating_sub(n50.unwrap_or(max_left)))
+                            + n50.unwrap_or(max_left),
+                    )),
+                    n100: n100.unwrap_or(max_left.saturating_sub(n50.unwrap_or(max_left))),
+                    n50: n50.unwrap_or(max_left),
+                    misses,
                 };
 
-                for new100 in min_n100..=max_n100 {
-                    let max_left = n_remaining.saturating_sub(new3x0 + new200 + new100);
+                let max_state = ManiaScoreState {
+                    n320: new320,
+                    n300: new300,
+                    n200: n200.unwrap_or(max_left),
+                    n100: n100.unwrap_or(max_left.saturating_sub(n200.unwrap_or(max_left))),
+                    n50: n50.unwrap_or(max_left.saturating_sub(
+                        n200.unwrap_or(max_left)
+                            + n100.unwrap_or(max_left.saturating_sub(n200.unwrap_or(max_left))),
+                    )),
+                    misses,
+                };
 
-                    let new50 = match n50 {
-                        Some(n50) if multiple_given => cmp::min(n_remaining, n50),
-                        Some(n50) => cmp::min(max_left, n50),
-                        None => max_left,
+                n300_iters += 1;
+
+                // Skip n200 and n100 iterations if we know we won't be able to
+                // get a better result.
+                if min_state.accuracy(classic) - best_dist > acc
+                    || max_state.accuracy(classic) + best_dist < acc
+                {
+                    n300_skips += 1;
+
+                    continue;
+                }
+
+                let (min_n200, max_n200) = match (n200, n100, n50) {
+                    (Some(n200), ..) if multiple_given => {
+                        (cmp::min(n_remaining, n200), cmp::min(n_remaining, n200))
+                    }
+                    (Some(n200), ..) => (cmp::min(max_left, n200), cmp::min(max_left, n200)),
+                    (None, Some(_), Some(_)) => (max_left, max_left),
+                    _ => (0, max_left),
+                };
+
+                for new200 in min_n200..=max_n200 {
+                    let max_left =
+                        n_remaining.saturating_sub(new320 + new300 + new200 + n50.unwrap_or(0));
+
+                    let (min_n100, max_n100) = match (n100, n50) {
+                        (Some(n100), _) if multiple_given => {
+                            (cmp::min(n_remaining, n100), cmp::min(n_remaining, n100))
+                        }
+                        (Some(n100), _) => (cmp::min(max_left, n100), cmp::min(max_left, n100)),
+                        (None, Some(_)) => (max_left, max_left),
+                        (None, None) => (0, max_left),
                     };
 
-                    let (new320, new300) = match (n320, n300) {
-                        (Some(n320), Some(n300)) => {
-                            (cmp::min(n_remaining, n320), cmp::min(n_remaining, n300))
-                        }
-                        (Some(n320), None) => (
-                            cmp::min(n320, n_remaining),
-                            new3x0 - cmp::min(n320, n_remaining),
-                        ),
-                        (None, Some(n300)) => (
-                            new3x0 - cmp::min(n300, n_remaining),
-                            cmp::min(n300, n_remaining),
-                        ),
-                        (None, None) if best_case => (new3x0, 0),
-                        (None, None) => (0, new3x0),
-                    };
+                    for new100 in min_n100..=max_n100 {
+                        let max_left =
+                            n_remaining.saturating_sub(new320 + new300 + new200 + new100);
 
-                    let curr_acc = accuracy(new320, new300, new200, new100, new50, misses);
-                    let curr_dist = (acc - curr_acc).abs();
+                        let new50 = match n50 {
+                            Some(n50) if multiple_given => cmp::min(n_remaining, n50),
+                            Some(n50) => cmp::min(max_left, n50),
+                            None => max_left,
+                        };
 
-                    let curr_custom_acc =
-                        custom_accuracy(new320, new300, new200, new100, new50, n_objects);
+                        let (new320, new300) = if classic {
+                            match (n320, n300) {
+                                (Some(n320), Some(n300)) => {
+                                    (cmp::min(n_remaining, n320), cmp::min(n_remaining, n300))
+                                }
+                                (Some(n320), None) => (
+                                    cmp::min(n320, n_remaining),
+                                    new320 - cmp::min(n320, n_remaining),
+                                ),
+                                (None, Some(n300)) => (
+                                    new320 - cmp::min(n300, n_remaining),
+                                    cmp::min(n300, n_remaining),
+                                ),
+                                (None, None) if best_case => (new320, 0),
+                                (None, None) => (0, new320),
+                            }
+                        } else {
+                            (new320, new300)
+                        };
 
-                    match curr_dist.total_cmp(&best_dist) {
-                        Ordering::Less => {
-                            best_dist = curr_dist;
-                            best_custom_acc = curr_custom_acc;
-                            best_state.n320 = new320;
-                            best_state.n300 = new300;
-                            best_state.n200 = new200;
-                            best_state.n100 = new100;
-                            best_state.n50 = new50;
+                        let curr_acc = ManiaScoreState {
+                            n320: new320,
+                            n300: new300,
+                            n200: new200,
+                            n100: new100,
+                            n50: new50,
+                            misses,
                         }
-                        Ordering::Equal if curr_custom_acc < best_custom_acc => {
-                            best_custom_acc = curr_custom_acc;
-                            best_state.n320 = new320;
-                            best_state.n300 = new300;
-                            best_state.n200 = new200;
-                            best_state.n100 = new100;
-                            best_state.n50 = new50;
+                        .accuracy(classic);
+
+                        let curr_dist = (acc - curr_acc).abs();
+
+                        let curr_custom_acc =
+                            custom_accuracy(new320, new300, new200, new100, new50, n_objects);
+
+                        match curr_dist.total_cmp(&best_dist) {
+                            Ordering::Less => {
+                                best_dist = curr_dist;
+                                best_custom_acc = curr_custom_acc;
+                                best_state.n320 = new320;
+                                best_state.n300 = new300;
+                                best_state.n200 = new200;
+                                best_state.n100 = new100;
+                                best_state.n50 = new50;
+                            }
+                            Ordering::Equal if curr_custom_acc < best_custom_acc => {
+                                best_custom_acc = curr_custom_acc;
+                                best_state.n320 = new320;
+                                best_state.n300 = new300;
+                                best_state.n200 = new200;
+                                best_state.n100 = new100;
+                                best_state.n50 = new50;
+                            }
+                            _ => {}
                         }
-                        _ => {}
                     }
                 }
             }
         }
+
+        eprintln!("Bruteforce skipped {n300_skips}/{n300_iters} n300 iterations");
 
         if best_state.n320 + best_state.n300 + best_state.n200 + best_state.n100 + best_state.n50
             < n_remaining
@@ -1104,58 +1018,70 @@ mod tests {
             }
         }
 
-        if best_case {
-            if n320.is_none() && n200.is_none() && n100.is_none() {
-                let n = best_state.n200 / 2;
-                best_state.n320 += n;
-                best_state.n200 -= 2 * n;
-                best_state.n100 += n;
+        if classic && n320.is_none() {
+            let before = best_state.clone();
+
+            if n300.is_none() {
+                best_state.n320 += best_state.n300;
+                best_state.n300 = 0;
             }
 
-            if n100.is_none() && n50.is_none() {
-                let n = if n320.is_none() && n300.is_none() {
-                    let n = cmp::min(best_state.n320 + best_state.n300, best_state.n50 / 4);
+            if best_case {
+                if n100.is_none() && n200.is_none() {
+                    let n = best_state.n200 / 2;
+                    best_state.n320 += n;
+                    best_state.n200 -= 2 * n;
+                    best_state.n100 += n;
+                }
 
-                    let removed320 = cmp::min(best_state.n320, n);
-                    let removed300 = n - removed320;
+                if n50.is_none() && n200.is_none() {
+                    let n = best_state.n200 / 5;
+                    best_state.n320 += n * 3;
+                    best_state.n200 -= n * 5;
+                    best_state.n50 += n * 2;
+                }
 
-                    best_state.n320 -= removed320;
-                    best_state.n300 -= removed300;
-
-                    n
-                } else if n320.is_none() {
-                    let n = cmp::min(best_state.n320, best_state.n50 / 4);
+                if n300.is_none() {
+                    best_state.n320 += best_state.n300;
+                    best_state.n300 = 0;
+                }
+            } else {
+                if n100.is_none() && n200.is_none() {
+                    let n = cmp::min(best_state.n320, best_state.n100);
                     best_state.n320 -= n;
+                    best_state.n200 += 2 * n;
+                    best_state.n100 -= n;
+                }
 
-                    n
-                } else if n300.is_none() {
-                    let n = cmp::min(best_state.n300, best_state.n50 / 4);
-                    best_state.n300 -= n;
+                if n50.is_none() && n200.is_none() {
+                    let n = cmp::min(best_state.n320 / 3, best_state.n50 / 2);
+                    best_state.n320 -= n * 3;
+                    best_state.n200 += n * 5;
+                    best_state.n50 -= n * 2;
+                }
 
-                    n
-                } else {
-                    0
-                };
-
-                best_state.n100 += 5 * n;
-                best_state.n50 -= 4 * n;
+                if n300.is_none() {
+                    best_state.n300 += best_state.n320;
+                    best_state.n320 = 0;
+                }
             }
-        } else if n320.is_none() && n200.is_none() && n100.is_none() {
-            let n = cmp::min(best_state.n320, best_state.n100);
-            best_state.n320 -= n;
-            best_state.n200 += 2 * n;
-            best_state.n100 -= n;
+
+            assert_eq!(best_state.accuracy(classic), before.accuracy(classic));
         }
 
         best_state
     }
 
     proptest! {
-        #![proptest_config(ProptestConfig::with_cases(50))]
+        #![proptest_config(ProptestConfig {
+            cases: 20,
+            ..Default::default()
+        })]
 
         #[test]
+        #[ignore = "cannot skip persistent failure cases for some reason which run way too slowly"]
         fn mania_hitresults(
-            lazer in prop::bool::ANY,
+            classic in prop::bool::ANY,
             acc in 0.0_f64..=1.0,
             n320 in prop::option::weighted(0.10, 0_u32..=N_OBJECTS + N_HOLD_NOTES + 10),
             n300 in prop::option::weighted(0.10, 0_u32..=N_OBJECTS + N_HOLD_NOTES + 10),
@@ -1165,65 +1091,154 @@ mod tests {
             n_misses in prop::option::weighted(0.15, 0_u32..=N_OBJECTS + N_HOLD_NOTES + 10),
             best_case in prop::bool::ANY,
         ) {
-            let priority = if best_case {
-                HitResultPriority::BestCase
-            } else {
-                HitResultPriority::WorstCase
-            };
-
-            let mut state = ManiaPerformance::from(attrs())
-                .accuracy(acc * 100.0)
-                .lazer(lazer)
-                .hitresult_priority(priority);
-
-            if let Some(n320) = n320 {
-                state = state.n320(n320);
-            }
-
-            if let Some(n300) = n300 {
-                state = state.n300(n300);
-            }
-
-            if let Some(n200) = n200 {
-                state = state.n200(n200);
-            }
-
-            if let Some(n100) = n100 {
-                state = state.n100(n100);
-            }
-
-            if let Some(n50) = n50 {
-                state = state.n50(n50);
-            }
-
-            if let Some(misses) = n_misses {
-                state = state.misses(misses);
-            }
-
-            let first = state.generate_state().unwrap();
-            let state = state.generate_state().unwrap();
-            assert_eq!(first, state);
-
-            let expected = brute_force_best(
-                lazer,
-                acc,
-                n320,
-                n300,
-                n200,
-                n100,
-                n50,
-                n_misses.unwrap_or(0),
-                best_case,
-            );
-
-            assert_eq!(state, expected);
+            exec_mania_hitresults(classic, acc, n320, n300, n200, n100, n50, n_misses, best_case);
         }
     }
 
     #[test]
+    fn rng_mania_hitresults() {
+        /// Generates a random seed by measuring the time it takes to calculate
+        /// all primes up to 10_000.
+        fn generate_seed() -> [u8; 16] {
+            let start = Instant::now();
+
+            const LIMIT: usize = 10_000;
+            let mut is_prime = vec![true; LIMIT + 1];
+            is_prime.iter_mut().step_by(2).for_each(|n| *n = false);
+            is_prime[1] = false;
+            is_prime[2] = true;
+
+            for n in (3..=LIMIT).step_by(2) {
+                if !is_prime[n] {
+                    continue;
+                }
+
+                for m in (n * n..=LIMIT).step_by(n) {
+                    is_prime[m] = false;
+                }
+            }
+
+            start.elapsed().as_nanos().to_le_bytes()
+        }
+
+        let seed = generate_seed();
+        eprintln!("seed={seed:?}");
+        let mut rng = TestRng::from_seed(RngAlgorithm::XorShift, &seed);
+
+        // Worst-case test cases can take over 5 minutes to bruteforce on debug
+        // mode so we shouldn't over do the amount here.
+        const CASES: usize = 4;
+
+        for _ in 0..CASES {
+            const LIMIT: u32 = N_OBJECTS + N_HOLD_NOTES + 10;
+
+            let classic = rng.gen();
+            let acc = rng.gen_range(0.0..=1.0);
+            let n320 = rng.gen_bool(0.1).then(|| rng.gen_range(0..=LIMIT));
+            let n300 = rng.gen_bool(0.1).then(|| rng.gen_range(0..=LIMIT));
+            let n200 = rng.gen_bool(0.1).then(|| rng.gen_range(0..=LIMIT));
+            let n100 = rng.gen_bool(0.1).then(|| rng.gen_range(0..=LIMIT));
+            let n50 = rng.gen_bool(0.1).then(|| rng.gen_range(0..=LIMIT));
+            let n_misses = rng.gen_bool(0.2).then(|| rng.gen_range(0..=LIMIT));
+            let best_case = rng.gen();
+
+            eprintln!(
+                "classic={} | acc={} | n320={:?} | n300={:?} | n200={:?} | \
+                n100={:?} | n50={:?} | n_misses={:?} | best_case={}",
+                classic, acc, n320, n300, n200, n100, n50, n_misses, best_case,
+            );
+
+            exec_mania_hitresults(
+                classic, acc, n320, n300, n200, n100, n50, n_misses, best_case,
+            );
+        }
+    }
+
+    fn exec_mania_hitresults(
+        classic: bool,
+        acc: f64,
+        n320: Option<u32>,
+        n300: Option<u32>,
+        n200: Option<u32>,
+        n100: Option<u32>,
+        n50: Option<u32>,
+        n_misses: Option<u32>,
+        best_case: bool,
+    ) {
+        let priority = if best_case {
+            HitResultPriority::BestCase
+        } else {
+            HitResultPriority::WorstCase
+        };
+
+        let mut state = ManiaPerformance::from(attrs())
+            .accuracy(acc * 100.0)
+            .lazer(!classic)
+            .mods(mods(classic))
+            .hitresult_priority(priority);
+
+        if let Some(n320) = n320 {
+            state = state.n320(n320);
+        }
+
+        if let Some(n300) = n300 {
+            state = state.n300(n300);
+        }
+
+        if let Some(n200) = n200 {
+            state = state.n200(n200);
+        }
+
+        if let Some(n100) = n100 {
+            state = state.n100(n100);
+        }
+
+        if let Some(n50) = n50 {
+            state = state.n50(n50);
+        }
+
+        if let Some(misses) = n_misses {
+            state = state.misses(misses);
+        }
+
+        let start = Instant::now();
+        let first = state.generate_state().unwrap();
+        let state_elapsed = start.elapsed();
+        let state = state.generate_state().unwrap();
+        assert_eq!(first, state);
+
+        let start = Instant::now();
+        let expected = brute_force_best(
+            classic,
+            acc,
+            n320,
+            n300,
+            n200,
+            n100,
+            n50,
+            n_misses.unwrap_or(0),
+            best_case,
+        );
+        let bf_elapsed = start.elapsed();
+
+        eprintln!("Elapsed: state={state_elapsed:?} bf={bf_elapsed:?}");
+
+        assert_eq!(
+            state,
+            expected,
+            "dist: {} vs {}",
+            (state.accuracy(classic) - acc).abs(),
+            (expected.accuracy(classic) - acc).abs(),
+        );
+    }
+
+    #[test]
     fn hitresults_n320_misses_best() {
+        let classic = true;
+
         let state = ManiaPerformance::from(attrs())
-            .lazer(false)
+            .lazer(!classic)
+            .mods(mods(classic))
             .n320(500)
             .misses(2)
             .hitresult_priority(HitResultPriority::BestCase)
@@ -1244,8 +1259,11 @@ mod tests {
 
     #[test]
     fn hitresults_n100_n50_misses_worst() {
+        let classic = true;
+
         let state = ManiaPerformance::from(attrs())
-            .lazer(false)
+            .lazer(!classic)
+            .mods(mods(classic))
             .n100(200)
             .n50(50)
             .misses(2)

--- a/src/mania/score_state.rs
+++ b/src/mania/score_state.rs
@@ -41,13 +41,13 @@ impl ManiaScoreState {
             return 0.0;
         }
 
-        let perfect_weight = if classic { 300 } else { 305 };
+        let perfect_weight = if classic { 60 } else { 61 };
 
         let numerator = perfect_weight * self.n320
-            + 300 * self.n300
-            + 200 * self.n200
-            + 100 * self.n100
-            + 50 * self.n50;
+            + 60 * self.n300
+            + 40 * self.n200
+            + 20 * self.n100
+            + 10 * self.n50;
 
         let denominator = perfect_weight * total_hits;
 

--- a/src/mania/score_state.rs
+++ b/src/mania/score_state.rs
@@ -34,15 +34,22 @@ impl ManiaScoreState {
     }
 
     /// Calculate the accuracy between `0.0` and `1.0` for this state.
-    pub fn accuracy(&self) -> f64 {
+    pub fn accuracy(&self, classic: bool) -> f64 {
         let total_hits = self.total_hits();
 
         if total_hits == 0 {
             return 0.0;
         }
 
-        let numerator = 6 * (self.n320 + self.n300) + 4 * self.n200 + 2 * self.n100 + self.n50;
-        let denominator = 6 * total_hits;
+        let perfect_weight = if classic { 300 } else { 305 };
+
+        let numerator = perfect_weight * self.n320
+            + 300 * self.n300
+            + 200 * self.n200
+            + 100 * self.n100
+            + 50 * self.n50;
+
+        let denominator = perfect_weight * total_hits;
 
         f64::from(numerator) / f64::from(denominator)
     }

--- a/src/model/mods.rs
+++ b/src/model/mods.rs
@@ -314,6 +314,7 @@ impl_has_mod! {
     so: + SpunOut ["SpunOut"],
     ap: + Autopilot ["Autopilot"],
     bl: - Blinds ["Blinds"],
+    cl: - Classic ["Classic"],
     tc: - Traceable ["Traceable"],
 }
 


### PR DESCRIPTION
Fixes #52 

The `ManiaScoreState::accuracy` method now takes a `classic: bool` argument which is a breaking change.

Hitresult generation for mania has been rewritten from scratch; its bruteforce for testing is considerably slower now unfortunately.