### PR TITLE
feat: improve suspicion heuristic

### DIFF
--- a/src/model/beatmap/mod.rs
+++ b/src/model/beatmap/mod.rs
@@ -192,7 +192,7 @@ impl Beatmap {
     /// should likely be avoided on these maps due to potential performance
     /// issues.
     pub fn check_suspicion(&self) -> Result<(), TooSuspicious> {
-        match TooSuspicious::new(&self.hit_objects) {
+        match TooSuspicious::new(self) {
             None => Ok(()),
             Some(err) => Err(err),
         }

--- a/src/model/beatmap/suspicious.rs
+++ b/src/model/beatmap/suspicious.rs
@@ -1,11 +1,13 @@
 use std::{error, fmt};
 
-use rosu_map::util::Pos;
+use rosu_map::{section::general::GameMode, util::Pos};
 
 use crate::{
     model::hit_object::{HitObject, HitObjectKind},
     util::hint::unlikely,
 };
+
+use super::Beatmap;
 
 /// Resulting error type of [`Beatmap::check_suspicion`].
 ///
@@ -18,8 +20,12 @@ use crate::{
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum TooSuspicious {
+    /// Notes are too dense time-wise.
+    Density,
     /// The map seems too long.
     Length,
+    /// Too many objects.
+    ObjectCount,
     /// General red flag.
     RedFlag,
     /// Too many sliders' positions were suspicious.
@@ -29,10 +35,10 @@ pub enum TooSuspicious {
 }
 
 impl TooSuspicious {
-    pub(crate) fn new(hit_objects: &[HitObject]) -> Option<Self> {
+    pub(crate) fn new(map: &Beatmap) -> Option<Self> {
         #[inline]
         const fn too_long(hit_objects: &[HitObject]) -> bool {
-            const DAY_IN_MS: u32 = 60 * 60 * 24 * 1000;
+            const DAY_MS: u32 = 60 * 60 * 24 * 1000;
 
             if unlikely(hit_objects.len() < 2) {
                 return false;
@@ -42,20 +48,103 @@ impl TooSuspicious {
                 unreachable!()
             };
 
-            unlikely((last.start_time - first.start_time) > DAY_IN_MS as f64)
+            (last.start_time - first.start_time) > DAY_MS as f64
         }
 
-        if unlikely(too_long(hit_objects)) {
+        #[inline]
+        fn too_many_objects(map: &Beatmap) -> bool {
+            const THRESHOLD: usize = 500_000;
+            /// Taiko calculation is especially expensive for high object counts
+            const THRESHOLD_TAIKO: usize = 20_000;
+
+            match map.mode {
+                GameMode::Taiko => map.hit_objects.len() > THRESHOLD_TAIKO,
+                _ => map.hit_objects.len() > THRESHOLD,
+            }
+        }
+
+        #[inline]
+        fn too_dense(i: usize, curr: &HitObject, map: &Beatmap) -> bool {
+            const fn too_dense<const PER_1S: usize, const PER_10S: usize>(
+                i: usize,
+                curr: &HitObject,
+                hit_objects: &[HitObject],
+            ) -> bool {
+                (hit_objects.len() > i + PER_1S
+                    && hit_objects[i + PER_1S].start_time - curr.start_time < 1000.0)
+                    || (hit_objects.len() > i + PER_10S
+                        && hit_objects[i + PER_10S].start_time - curr.start_time < 10_000.0)
+            }
+
+            match map.mode {
+                GameMode::Mania => {
+                    // In mania it's more common to have a high note density
+                    const THRESHOLD_1S: usize = 200; // 200 4K notes per 1s = 3000BPM
+                    const THRESHOLD_10S: usize = 500; // 500 4K notes per 10s = 750BPM
+
+                    too_dense::<THRESHOLD_1S, THRESHOLD_10S>(i, curr, &map.hit_objects)
+                }
+                _ => {
+                    const THRESHOLD_1S: usize = 100; // 100 notes per 1s = 6000BPM
+                    const THRESHOLD_10S: usize = 250; // 250 notes per 10s = 1500BPM
+
+                    too_dense::<THRESHOLD_1S, THRESHOLD_10S>(i, curr, &map.hit_objects)
+                }
+            }
+        }
+
+        #[inline]
+        const fn check_pos(pos: Pos) -> bool {
+            /// osu!'s max value is `131_072` and the playfield is `512x384`
+            const THRESHOLD: f32 = 10_000.0;
+
+            f32::abs(pos.x) > THRESHOLD || f32::abs(pos.y) > THRESHOLD
+        }
+
+        #[inline]
+        const fn check_repeats(repeats: usize) -> bool {
+            /// osu!'s max value is `9000`
+            const THRESHOLD: usize = 1000;
+
+            repeats > THRESHOLD
+        }
+
+        if unlikely(too_many_objects(map)) {
+            return Some(Self::ObjectCount);
+        } else if unlikely(too_long(&map.hit_objects)) {
             return Some(Self::Length);
         }
 
-        let tracker = ValueTracker::new(hit_objects);
+        let mut pos_beyond_threshold = 0;
+        let mut repeats_beyond_threshold = 0;
 
-        if unlikely(tracker.red_flag) {
-            Some(Self::RedFlag)
-        } else if unlikely(tracker.pos_beyond_threshold > 256) {
+        for (i, h) in map.hit_objects.iter().enumerate() {
+            if unlikely(too_dense(i, h, map)) {
+                return Some(Self::Density);
+            }
+
+            if let HitObjectKind::Slider(ref slider) = h.kind {
+                if unlikely(check_repeats(slider.repeats)) {
+                    if unlikely(
+                        check_pos(h.pos) && matches!(map.mode, GameMode::Osu | GameMode::Catch),
+                    ) {
+                        return Some(Self::RedFlag);
+                    }
+
+                    repeats_beyond_threshold += 1;
+                } else if unlikely(check_pos(h.pos)) {
+                    pos_beyond_threshold += 1;
+                }
+            }
+        }
+
+        if matches!(map.mode, GameMode::Taiko | GameMode::Mania) {
+            // Taiko and Mania calculations aren't as susceptible to malicious
+            // slider values
+            None
+        } else if unlikely(pos_beyond_threshold > 256) {
             Some(Self::SliderPositions)
-        } else if unlikely(tracker.repeats_beyond_threshold > 256) {
+        } else if unlikely(repeats_beyond_threshold > 256) {
             Some(Self::SliderRepeats)
         } else {
             None
@@ -69,63 +158,7 @@ impl fmt::Display for TooSuspicious {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "the hit objects seem too suspicious for further calculation \
-            (reason={self:?})",
+            "the map seems too suspicious for further calculation (reason={self:?})",
         )
-    }
-}
-
-pub(crate) struct ValueTracker {
-    pos_beyond_threshold: usize,
-    repeats_beyond_threshold: usize,
-    red_flag: bool,
-}
-
-impl ValueTracker {
-    /// osu!'s max value is `131_072` and the playfield is `512x384`
-    const POS_THRESHOLD: f32 = 10_000.0;
-
-    /// osu!'s max value is `9000`
-    const REPEATS_THRESHOLD: usize = 1000;
-
-    fn new(hit_objects: &[HitObject]) -> Self {
-        let mut this = Self {
-            pos_beyond_threshold: 0,
-            repeats_beyond_threshold: 0,
-            red_flag: false,
-        };
-
-        for h in hit_objects {
-            this.process(h);
-        }
-
-        this
-    }
-
-    const fn process(&mut self, h: &HitObject) {
-        #[inline]
-        const fn check_pos(pos: Pos) -> bool {
-            unlikely(
-                f32::abs(pos.x) > ValueTracker::POS_THRESHOLD
-                    || f32::abs(pos.y) > ValueTracker::POS_THRESHOLD,
-            )
-        }
-
-        #[inline]
-        const fn check_repeats(repeats: usize) -> bool {
-            unlikely(repeats > ValueTracker::REPEATS_THRESHOLD)
-        }
-
-        if let HitObjectKind::Slider(ref slider) = h.kind {
-            if check_repeats(slider.repeats) {
-                self.repeats_beyond_threshold += 1;
-
-                if check_pos(h.pos) {
-                    self.red_flag = true;
-                }
-            } else if check_pos(h.pos) {
-                self.pos_beyond_threshold += 1;
-            }
-        }
     }
 }


### PR DESCRIPTION
Improves upon #56 

Now also
- distinguishes between modes
- considers plain hit object count
- 1 second and 10 second densities of hit objects