### PR TITLE
fix: clamp hitresult in fast gen

### DIFF
--- a/src/osu/performance/mod.rs
+++ b/src/osu/performance/mod.rs
@@ -466,9 +466,12 @@ impl<'map> OsuPerformance<'map> {
                         //     (300N + S) - 300A - 50C - s = 100B
                         // <=> (300N + S) - 50R - 250A - s = 50B
                         // <=> ((300N + S) - 50R - 250A - s) / 50 = B
-                        n100 = (f64::round(target_total) as u32)
-                            .saturating_sub(50 * n_remaining + 250 * n300 + slider_acc_value)
-                            / 50;
+                        n100 = u32::min(
+                            n_remaining.saturating_sub(n300),
+                            (f64::round(target_total) as u32)
+                                .saturating_sub(50 * n_remaining + 250 * n300 + slider_acc_value)
+                                / 50,
+                        );
                         n50 = n_objects.saturating_sub(n300 + n100 + misses);
                     } else {
                         let mut best_dist = f64::MAX;
@@ -510,9 +513,12 @@ impl<'map> OsuPerformance<'map> {
                         //     (300N + S)a - 100B - 50C - s = 300A
                         // <=> (300N + S)a - 50R - 50B - s = 250A
                         // <=> ((300N + S)a - 50R - 50B - s) / 250 = A
-                        n300 = (f64::round(target_total) as u32)
-                            .saturating_sub(50 * n_remaining + 50 * n100 + slider_acc_value)
-                            / 250;
+                        n300 = u32::min(
+                            n_remaining.saturating_sub(n100),
+                            (f64::round(target_total) as u32)
+                                .saturating_sub(50 * n_remaining + 50 * n100 + slider_acc_value)
+                                / 250,
+                        );
                         n50 = n_objects.saturating_sub(n300 + n100 + misses);
                     } else {
                         let mut best_dist = f64::MAX;
@@ -554,9 +560,12 @@ impl<'map> OsuPerformance<'map> {
                         //     (300N + S)a - 100B - 50C - s = 300A
                         // <=> (300N + S)a - 100R + 50C - s = 200A
                         // <=> ((300N + S)a - 100R + 50C - s) / 200 = A
-                        n300 = (f64::round(target_total) as u32 + 50 * n50)
-                            .saturating_sub(100 * n_remaining + slider_acc_value)
-                            / 200;
+                        n300 = u32::min(
+                            n_remaining.saturating_sub(n50),
+                            (f64::round(target_total) as u32 + 50 * n50)
+                                .saturating_sub(100 * n_remaining + slider_acc_value)
+                                / 200,
+                        );
                         n100 = n_objects.saturating_sub(n300 + n50 + misses);
                     } else {
                         let mut best_dist = f64::MAX;
@@ -606,8 +615,8 @@ impl<'map> OsuPerformance<'map> {
                         let delta = (f64::round_ties_even(target_total) as u32)
                             .saturating_sub(50 * n_remaining + slider_acc_value);
 
-                        n300 = delta / 250;
-                        n100 = (delta % 250) / 50;
+                        n300 = u32::min(n_remaining, delta / 250);
+                        n100 = u32::min(n_remaining - n300, (delta % 250) / 50);
                         n50 = n_objects.saturating_sub(n300 + n100 + misses);
                     } else {
                         let mut best_dist = f64::MAX;

--- a/src/taiko/performance/mod.rs
+++ b/src/taiko/performance/mod.rs
@@ -254,7 +254,10 @@ impl<'map> TaikoPerformance<'map> {
                     let target_total = acc * f64::from(2 * total_result_count);
 
                     if let HitResultPriority::Fastest = priority {
-                        n300 = f64::round_ties_even(target_total) as u32 - n_remaining;
+                        n300 = u32::min(
+                            n_remaining,
+                            (f64::round_ties_even(target_total) as u32).saturating_sub(n_remaining),
+                        );
                         n100 = total_result_count.saturating_sub(n300 + misses);
                     } else {
                         let mut best_dist = f64::MAX;


### PR DESCRIPTION
Calculating performance by accuracy on niche maps like [/b/4756040](https://osu.ppy.sh/beatmapsets/2238314#osu/4756040) with only 5 sliders and no other notes used to cause issues.