### PR TITLE
feat: consider clock rate in map attrs

### DIFF
--- a/src/model/beatmap/attributes.rs
+++ b/src/model/beatmap/attributes.rs
@@ -385,7 +385,7 @@ impl BeatmapAttributesBuilder {
     /// # Panics
     ///
     /// Panics if the mode is not [`GameMode::Osu`].
-    pub fn build_peppy_stars(self) -> PeppyStarsBeatmapAttributes {
+    pub(crate) fn build_peppy_stars(self) -> PeppyStarsBeatmapAttributes {
         debug_assert_eq!(self.mode, GameMode::Osu);
 
         let mut raw_od = self.od.value(&self.mods, GameMods::od);

--- a/src/model/beatmap/attributes.rs
+++ b/src/model/beatmap/attributes.rs
@@ -1,7 +1,10 @@
 use rosu_map::section::general::GameMode;
 
 use crate::{
-    Difficulty, any::difficulty::ModsDependent, model::mods::GameMods, util::float_ext::FloatExt,
+    Difficulty,
+    any::difficulty::ModsDependent,
+    model::mods::GameMods,
+    util::{float_ext::FloatExt, ruleset_ext::PeppyStarsBeatmapAttributes},
 };
 
 use super::Beatmap;
@@ -375,48 +378,44 @@ impl BeatmapAttributesBuilder {
         }
     }
 
+    /// Calculate the [`PeppyStarsBeatmapAttributes`].
+    ///
+    /// Importantly, the OD value will not consider adjusted clock rates.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the mode is not [`GameMode::Osu`].
+    pub fn build_peppy_stars(self) -> PeppyStarsBeatmapAttributes {
+        debug_assert_eq!(self.mode, GameMode::Osu);
+
+        let mut raw_od = self.od.value(&self.mods, GameMods::od);
+
+        if !self.od.with_mods() {
+            raw_od = apply_mods_mult(&self.mods, raw_od);
+        }
+
+        PeppyStarsBeatmapAttributes {
+            od: f64::from(raw_od),
+            cs: self.build_cs(),
+            hp: self.build_hp(),
+        }
+    }
+
     /// Calculate the [`BeatmapAttributes`].
     pub fn build(&self) -> BeatmapAttributes {
         let mods = &self.mods;
         let clock_rate = self.clock_rate.unwrap_or_else(|| mods.clock_rate());
 
-        // HP
-        let mut hp = self.hp.value(mods, GameMods::hp);
-
-        if !self.hp.with_mods() {
-            hp *= mods.od_ar_hp_multiplier() as f32;
-        }
-
-        hp = hp.min(10.0);
-
-        // CS
-        let mut cs = self.cs.value(mods, GameMods::cs);
-
-        if !self.cs.with_mods() {
-            if mods.hr() {
-                cs = (cs * 1.3).min(10.0);
-            } else if mods.ez() {
-                cs *= 0.5;
-            }
-        }
-
         let hit_windows = self.hit_windows();
 
-        // AR
-        let ar = AR_WINDOWS.inverse_difficulty_range(hit_windows.ar);
-
-        // OD
-        let mut raw_od = self.od.value(mods, GameMods::od);
-
         let od = match self.mode {
-            GameMode::Osu | GameMode::Taiko | GameMode::Catch => {
-                if !self.od.with_mods() {
-                    raw_od = apply_mods_mult(mods, raw_od);
-                }
-
-                f64::from(raw_od)
+            GameMode::Osu => Self::osu_great_hit_window_to_od(hit_windows.od_great),
+            GameMode::Taiko => {
+                (TAIKO_GREAT.min - hit_windows.od_great) / (TAIKO_GREAT.min - TAIKO_GREAT.mid) * 5.0
             }
+            GameMode::Catch => 5.0,
             GameMode::Mania => {
+                let raw_od = self.od.value(mods, GameMods::od);
                 let mut perfect_hit_window = MANIA_PERFECT.difficulty_range(f64::from(raw_od));
 
                 if mods.hr() {
@@ -430,10 +429,10 @@ impl BeatmapAttributesBuilder {
         };
 
         BeatmapAttributes {
-            ar,
+            ar: AR_WINDOWS.inverse_difficulty_range(hit_windows.ar),
             od,
-            cs: f64::from(cs),
-            hp: f64::from(hp),
+            cs: self.build_cs(),
+            hp: self.build_hp(),
             clock_rate,
             hit_windows,
         }
@@ -441,6 +440,30 @@ impl BeatmapAttributesBuilder {
 
     pub(crate) const fn osu_great_hit_window_to_od(hit_window: f64) -> f64 {
         (79.5 - hit_window) / 6.0
+    }
+
+    fn build_cs(&self) -> f64 {
+        let mut cs = self.cs.value(&self.mods, GameMods::cs);
+
+        if !self.cs.with_mods() {
+            if self.mods.hr() {
+                cs = (cs * 1.3).min(10.0);
+            } else if self.mods.ez() {
+                cs *= 0.5;
+            }
+        }
+
+        f64::from(cs)
+    }
+
+    fn build_hp(&self) -> f64 {
+        let mut hp = self.hp.value(&self.mods, GameMods::hp);
+
+        if !self.hp.with_mods() {
+            hp *= self.mods.od_ar_hp_multiplier() as f32;
+        }
+
+        f64::from(hp.min(10.0))
     }
 }
 

--- a/src/model/beatmap/attributes.rs
+++ b/src/model/beatmap/attributes.rs
@@ -86,68 +86,6 @@ pub struct BeatmapAttributesBuilder {
     clock_rate: Option<f64>,
 }
 
-struct GameModeHitWindows {
-    min: f64,
-    mid: f64,
-    max: f64,
-}
-
-const OSU_GREAT: GameModeHitWindows = GameModeHitWindows {
-    min: 80.0,
-    mid: 50.0,
-    max: 20.0,
-};
-
-const OSU_OK: GameModeHitWindows = GameModeHitWindows {
-    min: 140.0,
-    mid: 100.0,
-    max: 60.0,
-};
-
-const OSU_MEH: GameModeHitWindows = GameModeHitWindows {
-    min: 200.0,
-    mid: 150.0,
-    max: 100.0,
-};
-
-const TAIKO_GREAT: GameModeHitWindows = GameModeHitWindows {
-    min: 50.0,
-    mid: 35.0,
-    max: 20.0,
-};
-
-const TAIKO_OK: GameModeHitWindows = GameModeHitWindows {
-    min: 120.0,
-    mid: 80.0,
-    max: 50.0,
-};
-
-const AR_WINDOWS: GameModeHitWindows = GameModeHitWindows {
-    min: 1800.0,
-    mid: 1200.0,
-    max: 450.0,
-};
-
-const MANIA_PERFECT: GameModeHitWindows = GameModeHitWindows {
-    min: 22.4,
-    mid: 19.4,
-    max: 13.9,
-};
-
-impl GameModeHitWindows {
-    fn difficulty_range(&self, difficulty: f64) -> f64 {
-        let Self { min, mid, max } = *self;
-
-        BeatmapAttributesExt::difficulty_range(difficulty, min, mid, max)
-    }
-
-    fn inverse_difficulty_range(&self, difficulty_value: f64) -> f64 {
-        let Self { min, mid, max } = *self;
-
-        BeatmapAttributesExt::inverse_difficulty_range(difficulty_value, min, mid, max)
-    }
-}
-
 impl BeatmapAttributesBuilder {
     /// Create a new [`BeatmapAttributesBuilder`].
     ///
@@ -306,7 +244,7 @@ impl BeatmapAttributesBuilder {
             }
         };
 
-        let preempt = AR_WINDOWS.difficulty_range(f64::from(raw_ar)) / ar_clock_rate;
+        let preempt = hit_windows::AR.difficulty_range(f64::from(raw_ar)) / ar_clock_rate;
 
         // OD
         let (great, ok, meh) = match self.mode {
@@ -323,9 +261,12 @@ impl BeatmapAttributesBuilder {
 
                 let raw_od = f64::from(raw_od);
 
-                let great = (OSU_GREAT.difficulty_range(raw_od).floor() - 0.5) / od_clock_rate;
-                let ok = (OSU_OK.difficulty_range(raw_od).floor() - 0.5) / od_clock_rate;
-                let meh = (OSU_MEH.difficulty_range(raw_od).floor() - 0.5) / od_clock_rate;
+                let great = (hit_windows::osu::GREAT.difficulty_range(raw_od).floor() - 0.5)
+                    / od_clock_rate;
+                let ok =
+                    (hit_windows::osu::OK.difficulty_range(raw_od).floor() - 0.5) / od_clock_rate;
+                let meh =
+                    (hit_windows::osu::MEH.difficulty_range(raw_od).floor() - 0.5) / od_clock_rate;
 
                 (great, Some(ok), Some(meh))
             }
@@ -342,8 +283,10 @@ impl BeatmapAttributesBuilder {
 
                 let raw_od = f64::from(raw_od);
 
-                let great = (TAIKO_GREAT.difficulty_range(raw_od).floor() - 0.5) / od_clock_rate;
-                let ok = (TAIKO_OK.difficulty_range(raw_od).floor() - 0.5) / od_clock_rate;
+                let great = (hit_windows::taiko::GREAT.difficulty_range(raw_od).floor() - 0.5)
+                    / od_clock_rate;
+                let ok =
+                    (hit_windows::taiko::OK.difficulty_range(raw_od).floor() - 0.5) / od_clock_rate;
 
                 (great, Some(ok), None)
             }
@@ -395,9 +338,9 @@ impl BeatmapAttributesBuilder {
         }
 
         PeppyStarsBeatmapAttributes {
-            od: f64::from(raw_od),
             cs: self.build_cs(),
             hp: self.build_hp(),
+            od: f64::from(raw_od),
         }
     }
 
@@ -411,12 +354,15 @@ impl BeatmapAttributesBuilder {
         let od = match self.mode {
             GameMode::Osu => Self::osu_great_hit_window_to_od(hit_windows.od_great),
             GameMode::Taiko => {
-                (TAIKO_GREAT.min - hit_windows.od_great) / (TAIKO_GREAT.min - TAIKO_GREAT.mid) * 5.0
+                (hit_windows::taiko::GREAT.min - hit_windows.od_great)
+                    / (hit_windows::taiko::GREAT.min - hit_windows::taiko::GREAT.mid)
+                    * 5.0
             }
-            GameMode::Catch => 5.0,
+            GameMode::Catch => 5.0, // osu!catch has no OD anyway
             GameMode::Mania => {
                 let raw_od = self.od.value(mods, GameMods::od);
-                let mut perfect_hit_window = MANIA_PERFECT.difficulty_range(f64::from(raw_od));
+                let mut perfect_hit_window =
+                    hit_windows::mania::PERFECT.difficulty_range(f64::from(raw_od));
 
                 if mods.hr() {
                     perfect_hit_window /= 1.4;
@@ -424,12 +370,12 @@ impl BeatmapAttributesBuilder {
                     perfect_hit_window /= 1.0 / 1.4;
                 }
 
-                MANIA_PERFECT.inverse_difficulty_range(perfect_hit_window)
+                hit_windows::mania::PERFECT.inverse_difficulty_range(perfect_hit_window)
             }
         };
 
         BeatmapAttributes {
-            ar: AR_WINDOWS.inverse_difficulty_range(hit_windows.ar),
+            ar: hit_windows::AR.inverse_difficulty_range(hit_windows.ar),
             od,
             cs: self.build_cs(),
             hp: self.build_hp(),
@@ -510,6 +456,84 @@ impl ModsDependentKind {
             ModsDependentKind::Custom(inner) => inner.value,
         }
     }
+}
+
+mod hit_windows {
+    use super::BeatmapAttributesExt;
+
+    pub(super) struct GameModeHitWindows {
+        pub min: f64,
+        pub mid: f64,
+        pub max: f64,
+    }
+
+    impl GameModeHitWindows {
+        pub fn difficulty_range(&self, difficulty: f64) -> f64 {
+            let Self { min, mid, max } = *self;
+
+            BeatmapAttributesExt::difficulty_range(difficulty, min, mid, max)
+        }
+
+        pub fn inverse_difficulty_range(&self, difficulty_value: f64) -> f64 {
+            let Self { min, mid, max } = *self;
+
+            BeatmapAttributesExt::inverse_difficulty_range(difficulty_value, min, mid, max)
+        }
+    }
+
+    pub mod osu {
+        use super::GameModeHitWindows;
+
+        pub const GREAT: GameModeHitWindows = GameModeHitWindows {
+            min: 80.0,
+            mid: 50.0,
+            max: 20.0,
+        };
+
+        pub const OK: GameModeHitWindows = GameModeHitWindows {
+            min: 140.0,
+            mid: 100.0,
+            max: 60.0,
+        };
+
+        pub const MEH: GameModeHitWindows = GameModeHitWindows {
+            min: 200.0,
+            mid: 150.0,
+            max: 100.0,
+        };
+    }
+
+    pub mod taiko {
+        use super::GameModeHitWindows;
+
+        pub const GREAT: GameModeHitWindows = GameModeHitWindows {
+            min: 50.0,
+            mid: 35.0,
+            max: 20.0,
+        };
+
+        pub const OK: GameModeHitWindows = GameModeHitWindows {
+            min: 120.0,
+            mid: 80.0,
+            max: 50.0,
+        };
+    }
+
+    pub mod mania {
+        use super::GameModeHitWindows;
+
+        pub const PERFECT: GameModeHitWindows = GameModeHitWindows {
+            min: 22.4,
+            mid: 19.4,
+            max: 13.9,
+        };
+    }
+
+    pub const AR: GameModeHitWindows = GameModeHitWindows {
+        min: 1800.0,
+        mid: 1200.0,
+        max: 450.0,
+    };
 }
 
 #[cfg(test)]

--- a/src/osu/difficulty/gradual.rs
+++ b/src/osu/difficulty/gradual.rs
@@ -116,7 +116,10 @@ impl OsuGradualDifficulty {
 
         let skills = OsuSkills::new(mods, &scaling_factor, &map_attrs, time_preempt);
         let diff_objects = extend_lifetime(diff_objects.into_boxed_slice());
-        let score_simulator = GradualLegacyScoreSimulator::new(&map, map_attrs);
+
+        let map_attrs_peppy = map.attributes().difficulty(&difficulty).build_peppy_stars();
+
+        let score_simulator = GradualLegacyScoreSimulator::new(&map, map_attrs_peppy);
         let nested_score = GradualNestedScorePerObject::default();
 
         Ok(Self {

--- a/src/osu/difficulty/mod.rs
+++ b/src/osu/difficulty/mod.rs
@@ -46,7 +46,6 @@ pub fn difficulty(
         osu_objects,
         skills,
         mut attrs,
-        map_attrs,
     } = DifficultyValues::calculate(difficulty, &map);
 
     let mods = difficulty.get_mods();
@@ -59,9 +58,11 @@ pub fn difficulty(
     let score_attrs = simulator.simulate();
     attrs.maximum_legacy_combo_score = score_attrs.combo_score as f64;
 
+    let map_attrs_peppy = map.attributes().difficulty(difficulty).build_peppy_stars();
+
     attrs.legacy_score_base_multiplier = f64::from(OsuLegacyScoreSimulator::score_multiplier(
         &map,
-        &map_attrs,
+        &map_attrs_peppy,
         passed_objects,
     ));
 
@@ -109,7 +110,6 @@ pub struct DifficultyValues {
     pub osu_objects: Box<[OsuObject]>,
     pub skills: OsuSkills,
     pub attrs: OsuDifficultyAttributes,
-    pub map_attrs: BeatmapAttributes,
 }
 
 impl DifficultyValues {
@@ -151,7 +151,6 @@ impl DifficultyValues {
             osu_objects,
             skills,
             attrs,
-            map_attrs,
         }
     }
 

--- a/src/osu/legacy_score_simulator/gradual.rs
+++ b/src/osu/legacy_score_simulator/gradual.rs
@@ -5,7 +5,6 @@ use rosu_map::section::events::BreakPeriod;
 use crate::{
     Beatmap,
     any::hit_result::HitResult,
-    model::beatmap::BeatmapAttributes,
     osu::{
         legacy_score_simulator::{
             AddScoreComboMultiplier, IncreaseCombo, IsBonus, LegacyScoreAttributes,
@@ -13,12 +12,12 @@ use crate::{
         },
         object::{NestedSliderObjectKind, OsuObject, OsuObjectKind},
     },
-    util::ruleset_ext::calculate_difficulty_peppy_stars,
+    util::ruleset_ext::{PeppyStarsBeatmapAttributes, calculate_difficulty_peppy_stars},
 };
 
 pub struct GradualLegacyScoreSimulator {
-    map_attrs: BeatmapAttributes,
-    map_attrs_nomod: BeatmapAttributes,
+    map_attrs: PeppyStarsBeatmapAttributes,
+    map_attrs_nomod: PeppyStarsBeatmapAttributes,
     attrs: LegacyScoreAttributes,
     inner: super::LegacyScoreSimulatorInner,
     combo_score_factors: Vec<f64>,
@@ -31,10 +30,10 @@ pub struct GradualLegacyScoreSimulator {
 }
 
 impl GradualLegacyScoreSimulator {
-    pub fn new(map: &Beatmap, map_attrs: BeatmapAttributes) -> Self {
+    pub fn new(map: &Beatmap, map_attrs: PeppyStarsBeatmapAttributes) -> Self {
         Self {
             map_attrs,
-            map_attrs_nomod: map.attributes().build(),
+            map_attrs_nomod: map.attributes().build_peppy_stars(),
             attrs: LegacyScoreAttributes::default(),
             inner: LegacyScoreSimulatorInner::default(),
             combo_score_factors: Vec::new(),

--- a/src/osu/legacy_score_simulator/mod.rs
+++ b/src/osu/legacy_score_simulator/mod.rs
@@ -3,9 +3,8 @@ use rosu_map::section::general::GameMode;
 use crate::{
     Beatmap,
     any::hit_result::HitResult,
-    model::beatmap::BeatmapAttributes,
     osu::object::{NestedSliderObjectKind, OsuObject, OsuObjectKind},
-    util::ruleset_ext::calculate_difficulty_peppy_stars,
+    util::ruleset_ext::{PeppyStarsBeatmapAttributes, calculate_difficulty_peppy_stars},
 };
 
 pub mod gradual;
@@ -21,8 +20,7 @@ impl<'a> OsuLegacyScoreSimulator<'a> {
     pub fn new(osu_objects: &'a [OsuObject], map: &Beatmap, passed_objects: usize) -> Self {
         // Note that no mods are being applied here. Apparently, this is how
         // lazer wants to it /shrug
-        let map_attrs = map.attributes().build();
-
+        let map_attrs = map.attributes().build_peppy_stars();
         let score_multiplier = Self::score_multiplier(map, &map_attrs, passed_objects);
 
         Self {
@@ -35,7 +33,7 @@ impl<'a> OsuLegacyScoreSimulator<'a> {
 
     pub fn score_multiplier(
         map: &Beatmap,
-        map_attrs: &BeatmapAttributes,
+        map_attrs: &PeppyStarsBeatmapAttributes,
         passed_objects: usize,
     ) -> i32 {
         let hit_objects = &map.hit_objects;

--- a/src/osu/performance/mod.rs
+++ b/src/osu/performance/mod.rs
@@ -102,6 +102,8 @@ impl<'map> OsuPerformance<'map> {
     /// However, when passing previously calculated attributes, make sure they
     /// have been calculated for the same map and [`Difficulty`] settings.
     /// Otherwise, the final attributes will be incorrect.
+    ///
+    /// [`OsuDifficultyAttributes`]: crate::osu::OsuDifficultyAttributes
     pub fn new(map_or_attrs: impl IntoModePerformance<'map, Osu>) -> Self {
         map_or_attrs.into_performance()
     }

--- a/src/osu/strains.rs
+++ b/src/osu/strains.rs
@@ -37,7 +37,6 @@ pub fn strains(difficulty: &Difficulty, map: &Beatmap) -> Result<OsuStrains, Con
                 flashlight,
             },
         attrs: _,
-        map_attrs: _,
     } = DifficultyValues::calculate(difficulty, &map);
 
     Ok(OsuStrains {

--- a/src/util/hint.rs
+++ b/src/util/hint.rs
@@ -1,3 +1,5 @@
+#![allow(unused, reason = "useful regardless")]
+
 #[inline]
 #[cold]
 const fn cold() {}

--- a/src/util/ruleset_ext.rs
+++ b/src/util/ruleset_ext.rs
@@ -1,7 +1,11 @@
-use crate::model::beatmap::BeatmapAttributes;
+pub struct PeppyStarsBeatmapAttributes {
+    pub cs: f64,
+    pub hp: f64,
+    pub od: f64,
+}
 
 pub fn calculate_difficulty_peppy_stars(
-    map_attrs: &BeatmapAttributes,
+    map_attrs: &PeppyStarsBeatmapAttributes,
     object_count: i32,
     drain_len: i32,
 ) -> i32 {


### PR DESCRIPTION
Difficulty & performance calculation never accesses the `OD` value of beatmap attributes directly except for once in osu!standard's legacy logic where, for whatever reason, it does not consider clock rate.

Since users likely *do* expect map attributes to be adjusted based on clock rate, this PR adds a specific internal function to calculate clock-rate-less OD, and keep the regular calculation in tact just as before.