### PR TITLE
feat: add checked_* methods

### DIFF
--- a/src/any/calc_error.rs
+++ b/src/any/calc_error.rs
@@ -1,0 +1,49 @@
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+
+use crate::model::{beatmap::TooSuspicious, mode::ConvertError};
+
+/// Error type when beatmap conversion or its suspicion-check fails.
+#[derive(Copy, Clone, Debug)]
+pub enum CalculateError {
+    /// Conversion failed.
+    Convert(ConvertError),
+    /// Suspicion check failed.
+    Suspicion(TooSuspicious),
+}
+
+impl Error for CalculateError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            CalculateError::Convert(err) => Some(err),
+            CalculateError::Suspicion(err) => Some(err),
+        }
+    }
+}
+
+impl Display for CalculateError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str("Failed to calculate attributes")?;
+
+        match self {
+            CalculateError::Convert(_) => f.write_str(" (Convert)")?,
+            CalculateError::Suspicion(_) => f.write_str(" (Suspicion)")?,
+        }
+
+        Ok(())
+    }
+}
+
+impl From<ConvertError> for CalculateError {
+    fn from(value: ConvertError) -> Self {
+        CalculateError::Convert(value)
+    }
+}
+
+impl From<TooSuspicious> for CalculateError {
+    fn from(value: TooSuspicious) -> Self {
+        CalculateError::Suspicion(value)
+    }
+}

--- a/src/any/difficulty/gradual.rs
+++ b/src/any/difficulty/gradual.rs
@@ -5,7 +5,10 @@ use crate::{
     any::DifficultyAttributes,
     catch::{Catch, CatchGradualDifficulty},
     mania::{Mania, ManiaGradualDifficulty},
-    model::mode::{ConvertError, IGameMode},
+    model::{
+        beatmap::TooSuspicious,
+        mode::{ConvertError, IGameMode},
+    },
     osu::{Osu, OsuGradualDifficulty},
     taiko::{Taiko, TaikoGradualDifficulty},
 };
@@ -53,7 +56,18 @@ impl GradualDifficulty {
         Self::new_with_mode(difficulty, map, map.mode).expect("no conversion required")
     }
 
-    /// Create a [`GradualDifficulty`] for a [`Beatmap`] on a specific [`GameMode`].
+    /// Same as [`GradualDifficulty::new`] but verifies that the map is not
+    /// suspicious.
+    pub fn checked_new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, TooSuspicious> {
+        // This is fine because `Self::new` will use the map's mode so it won't
+        // be converted.
+        map.check_suspicion()?;
+
+        Ok(Self::new(difficulty, map))
+    }
+
+    /// Create a [`GradualDifficulty`] for a [`Beatmap`] on a specific
+    /// [`GameMode`].
     pub fn new_with_mode(
         difficulty: Difficulty,
         map: &Beatmap,

--- a/src/any/difficulty/mod.rs
+++ b/src/any/difficulty/mod.rs
@@ -7,10 +7,11 @@ use rosu_map::section::general::GameMode;
 
 use crate::{
     GradualDifficulty, GradualPerformance,
+    any::CalculateError,
     catch::Catch,
     mania::Mania,
     model::{
-        beatmap::{Beatmap, BeatmapAttribute, attributes::BeatmapDifficulty},
+        beatmap::{Beatmap, BeatmapAttribute, TooSuspicious, attributes::BeatmapDifficulty},
         mode::ConvertError,
         mods::GameMods,
     },
@@ -270,12 +271,29 @@ impl Difficulty {
         }
     }
 
+    /// Perform the difficulty calculation after verifying the map is not
+    /// suspicious.
+    pub fn checked_calculate(&self, map: &Beatmap) -> Result<DifficultyAttributes, TooSuspicious> {
+        map.check_suspicion()?;
+
+        Ok(self.calculate(map))
+    }
+
     /// Perform the difficulty calculation for a specific [`IGameMode`].
     pub fn calculate_for_mode<M: IGameMode>(
         &self,
         map: &Beatmap,
     ) -> Result<M::DifficultyAttributes, ConvertError> {
         M::difficulty(self, map)
+    }
+
+    /// Same as [`Difficulty::calculate_for_mode`] but verifies that the
+    /// [`Beatmap`] is not too suspicious for further calculation.
+    pub fn checked_calculate_for_mode<M: IGameMode>(
+        &self,
+        map: &Beatmap,
+    ) -> Result<M::DifficultyAttributes, CalculateError> {
+        M::checked_difficulty(self, map)
     }
 
     /// Perform the difficulty calculation but instead of evaluating the skill

--- a/src/any/mod.rs
+++ b/src/any/mod.rs
@@ -1,5 +1,6 @@
 pub use self::{
     attributes::{DifficultyAttributes, PerformanceAttributes},
+    calc_error::CalculateError,
     difficulty::{Difficulty, gradual::GradualDifficulty, inspect::InspectDifficulty},
     hitresult_generator::HitResultGenerator,
     performance::{
@@ -18,6 +19,7 @@ pub use self::{
 pub mod hitresult_generator;
 
 mod attributes;
+mod calc_error;
 pub(crate) mod difficulty;
 pub(crate) mod hit_result;
 mod performance;

--- a/src/any/performance/gradual.rs
+++ b/src/any/performance/gradual.rs
@@ -5,7 +5,10 @@ use crate::{
     any::{PerformanceAttributes, ScoreState},
     catch::{Catch, CatchGradualPerformance},
     mania::{Mania, ManiaGradualPerformance},
-    model::mode::{ConvertError, IGameMode},
+    model::{
+        beatmap::TooSuspicious,
+        mode::{ConvertError, IGameMode},
+    },
     osu::{Osu, OsuGradualPerformance},
     taiko::{Taiko, TaikoGradualPerformance},
 };
@@ -100,6 +103,16 @@ impl GradualPerformance {
     #[expect(clippy::missing_panics_doc, reason = "unreachable")]
     pub fn new(difficulty: Difficulty, map: &Beatmap) -> Self {
         Self::new_with_mode(difficulty, map, map.mode).expect("no conversion required")
+    }
+
+    /// Same as [`GradualPerformance::new`] but verifies that the map is not
+    /// suspicious.
+    pub fn checked_new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, TooSuspicious> {
+        // This is fine because `Self::new` will use the map's mode so it won't
+        // be converted.
+        map.check_suspicion()?;
+
+        Ok(Self::new(difficulty, map))
     }
 
     /// Create a [`GradualPerformance`] for a [`Beatmap`] on a specific [`GameMode`].

--- a/src/any/performance/mod.rs
+++ b/src/any/performance/mod.rs
@@ -2,9 +2,10 @@ use rosu_map::section::general::GameMode;
 
 use crate::{
     Difficulty, GameMods,
-    any::HitResultGenerator,
+    any::{CalculateError, HitResultGenerator},
     catch::{Catch, CatchPerformance},
     mania::{Mania, ManiaPerformance},
+    model::beatmap::TooSuspicious,
     osu::{Osu, OsuPerformance},
     taiko::{Taiko, TaikoPerformance},
 };
@@ -16,6 +17,8 @@ use super::{attributes::PerformanceAttributes, score_state::ScoreState};
 pub mod gradual;
 pub mod inspectable;
 pub mod into;
+
+const NO_CONVERSION_REQUIRED: &str = "no conversion required";
 
 /// Performance calculator on maps of any mode.
 #[derive(Clone, Debug, PartialEq)]
@@ -58,18 +61,36 @@ impl<'map> Performance<'map> {
     pub fn calculate(self) -> PerformanceAttributes {
         match self {
             Self::Osu(o) => {
-                PerformanceAttributes::Osu(o.calculate().expect("no conversion required"))
+                PerformanceAttributes::Osu(o.calculate().expect(NO_CONVERSION_REQUIRED))
             }
             Self::Taiko(t) => {
-                PerformanceAttributes::Taiko(t.calculate().expect("no conversion required"))
+                PerformanceAttributes::Taiko(t.calculate().expect(NO_CONVERSION_REQUIRED))
             }
             Self::Catch(f) => {
-                PerformanceAttributes::Catch(f.calculate().expect("no conversion required"))
+                PerformanceAttributes::Catch(f.calculate().expect(NO_CONVERSION_REQUIRED))
             }
             Self::Mania(m) => {
-                PerformanceAttributes::Mania(m.calculate().expect("no conversion required"))
+                PerformanceAttributes::Mania(m.calculate().expect(NO_CONVERSION_REQUIRED))
             }
         }
+    }
+
+    /// Same as [`Performance::calculate`] but verifies that the map is not too
+    /// suspicious.
+    pub fn checked_calculate(self) -> Result<PerformanceAttributes, TooSuspicious> {
+        let map_err = |err| match err {
+            CalculateError::Suspicion(err) => err,
+            CalculateError::Convert(_) => unreachable!("{}", NO_CONVERSION_REQUIRED),
+        };
+
+        let this = match self {
+            Self::Osu(o) => PerformanceAttributes::Osu(o.checked_calculate().map_err(map_err)?),
+            Self::Taiko(t) => PerformanceAttributes::Taiko(t.checked_calculate().map_err(map_err)?),
+            Self::Catch(f) => PerformanceAttributes::Catch(f.checked_calculate().map_err(map_err)?),
+            Self::Mania(m) => PerformanceAttributes::Mania(m.checked_calculate().map_err(map_err)?),
+        };
+
+        Ok(this)
     }
 
     /// Attempt to convert the map to the specified mode.
@@ -461,13 +482,34 @@ impl<'map> Performance<'map> {
     }
 
     /// Create the [`ScoreState`] that will be used for performance calculation.
+    ///
+    /// If this [`Performance`] contained a [`Beatmap`], it will be replaced
+    /// by the difficulty attributes of the mode.
+    ///
+    /// [`Beatmap`]: crate::Beatmap
     #[expect(clippy::missing_panics_doc, reason = "unreachable")]
     pub fn generate_state(&mut self) -> ScoreState {
         match self {
-            Self::Osu(o) => o.generate_state().expect("no conversion required").into(),
-            Self::Taiko(t) => t.generate_state().expect("no conversion required").into(),
-            Self::Catch(f) => f.generate_state().expect("no conversion required").into(),
-            Self::Mania(m) => m.generate_state().expect("no conversion required").into(),
+            Self::Osu(o) => o.generate_state().expect(NO_CONVERSION_REQUIRED).into(),
+            Self::Taiko(t) => t.generate_state().expect(NO_CONVERSION_REQUIRED).into(),
+            Self::Catch(f) => f.generate_state().expect(NO_CONVERSION_REQUIRED).into(),
+            Self::Mania(m) => m.generate_state().expect(NO_CONVERSION_REQUIRED).into(),
+        }
+    }
+
+    /// Same as [`Performance::generate_state`] but verifies that the map was
+    /// not suspicious.
+    pub fn checked_generate_state(&mut self) -> Result<ScoreState, TooSuspicious> {
+        let map_err = |err| match err {
+            CalculateError::Suspicion(err) => err,
+            CalculateError::Convert(_) => unreachable!("{}", NO_CONVERSION_REQUIRED),
+        };
+
+        match self {
+            Self::Osu(o) => o.checked_generate_state().map(From::from).map_err(map_err),
+            Self::Taiko(t) => t.checked_generate_state().map(From::from).map_err(map_err),
+            Self::Catch(f) => f.checked_generate_state().map(From::from).map_err(map_err),
+            Self::Mania(m) => m.checked_generate_state().map(From::from).map_err(map_err),
         }
     }
 }

--- a/src/catch/difficulty/gradual.rs
+++ b/src/catch/difficulty/gradual.rs
@@ -4,7 +4,7 @@ use rosu_map::section::general::GameMode;
 
 use crate::{
     Beatmap, Difficulty,
-    any::difficulty::skills::StrainSkill,
+    any::{CalculateError, difficulty::skills::StrainSkill},
     catch::{
         CatchDifficultyAttributes,
         attributes::{GradualObjectCount, ObjectCountBuilder},
@@ -68,40 +68,53 @@ pub struct CatchGradualDifficulty {
 impl CatchGradualDifficulty {
     /// Create a new difficulty attributes iterator for osu!catch maps.
     pub fn new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, ConvertError> {
-        let map = map.convert_ref(GameMode::Catch, difficulty.get_mods())?;
+        let map = super::prepare_map(&difficulty, map)?;
 
-        let clock_rate = difficulty.get_clock_rate();
+        Ok(new(difficulty, &map))
+    }
 
-        let CatchDifficultySetup { map_attrs, attrs } =
-            CatchDifficultySetup::new(&difficulty, &map);
+    /// Same as [`CatchGradualDifficulty::new`] but verifies that the map is not
+    /// suspicious.
+    pub fn checked_new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, CalculateError> {
+        let map = super::prepare_map(&difficulty, map)?;
+        map.check_suspicion()?;
 
-        let hr_offsets = difficulty.get_hardrock_offsets();
-        let reflection = difficulty.get_mods().reflection();
-        let mut count = ObjectCountBuilder::new_gradual();
+        Ok(new(difficulty, &map))
+    }
+}
 
-        let palpable_objects =
-            convert_objects(&map, &mut count, reflection, hr_offsets, map_attrs.cs());
+fn new(difficulty: Difficulty, map: &Beatmap) -> CatchGradualDifficulty {
+    debug_assert_eq!(map.mode, GameMode::Catch);
 
-        let mut half_catcher_width = Catcher::calculate_catch_width(map_attrs.cs()) * 0.5;
-        half_catcher_width *= 1.0 - ((map_attrs.cs() - 5.5).max(0.0) * 0.0625);
+    let clock_rate = difficulty.get_clock_rate();
 
-        let diff_objects = DifficultyValues::create_difficulty_objects(
-            clock_rate,
-            half_catcher_width,
-            palpable_objects.iter(),
-        );
+    let CatchDifficultySetup { map_attrs, attrs } = CatchDifficultySetup::new(&difficulty, map);
 
-        let count = count.into_gradual();
-        let movement = Movement::new(clock_rate);
+    let hr_offsets = difficulty.get_hardrock_offsets();
+    let reflection = difficulty.get_mods().reflection();
+    let mut count = ObjectCountBuilder::new_gradual();
 
-        Ok(Self {
-            idx: 0,
-            difficulty,
-            attrs,
-            count,
-            diff_objects,
-            movement,
-        })
+    let palpable_objects = convert_objects(map, &mut count, reflection, hr_offsets, map_attrs.cs());
+
+    let mut half_catcher_width = Catcher::calculate_catch_width(map_attrs.cs()) * 0.5;
+    half_catcher_width *= 1.0 - ((map_attrs.cs() - 5.5).max(0.0) * 0.0625);
+
+    let diff_objects = DifficultyValues::create_difficulty_objects(
+        clock_rate,
+        half_catcher_width,
+        palpable_objects.iter(),
+    );
+
+    let count = count.into_gradual();
+    let movement = Movement::new(clock_rate);
+
+    CatchGradualDifficulty {
+        idx: 0,
+        difficulty,
+        attrs,
+        count,
+        diff_objects,
+        movement,
     }
 }
 

--- a/src/catch/difficulty/mod.rs
+++ b/src/catch/difficulty/mod.rs
@@ -1,8 +1,13 @@
+use std::borrow::Cow;
+
 use rosu_map::section::general::GameMode;
 
 use crate::{
     Beatmap,
-    any::difficulty::{Difficulty, skills::StrainSkill},
+    any::{
+        CalculateError,
+        difficulty::{Difficulty, skills::StrainSkill},
+    },
     catch::{
         catcher::Catcher, convert::convert_objects, difficulty::object::CatchDifficultyObject,
     },
@@ -27,16 +32,39 @@ pub fn difficulty(
     difficulty: &Difficulty,
     map: &Beatmap,
 ) -> Result<CatchDifficultyAttributes, ConvertError> {
-    let map = map.convert_ref(GameMode::Catch, difficulty.get_mods())?;
+    let map = prepare_map(difficulty, map)?;
+
+    Ok(calculate_difficulty(difficulty, &map))
+}
+
+pub fn checked_difficulty(
+    difficulty: &Difficulty,
+    map: &Beatmap,
+) -> Result<CatchDifficultyAttributes, CalculateError> {
+    let map = prepare_map(difficulty, map)?;
+    map.check_suspicion()?;
+
+    Ok(calculate_difficulty(difficulty, &map))
+}
+
+fn prepare_map<'map>(
+    difficulty: &Difficulty,
+    map: &'map Beatmap,
+) -> Result<Cow<'map, Beatmap>, ConvertError> {
+    map.convert_ref(GameMode::Catch, difficulty.get_mods())
+}
+
+fn calculate_difficulty(difficulty: &Difficulty, map: &Beatmap) -> CatchDifficultyAttributes {
+    debug_assert_eq!(map.mode, GameMode::Catch);
 
     let DifficultyValues {
         movement,
         mut attrs,
-    } = DifficultyValues::calculate(difficulty, &map);
+    } = DifficultyValues::calculate(difficulty, map);
 
     DifficultyValues::eval(&mut attrs, movement.into_difficulty_value());
 
-    Ok(attrs)
+    attrs
 }
 
 pub struct CatchDifficultySetup {

--- a/src/catch/mod.rs
+++ b/src/catch/mod.rs
@@ -2,6 +2,7 @@ use rosu_map::section::general::GameMode;
 
 use crate::{
     Difficulty,
+    any::CalculateError,
     model::{
         beatmap::Beatmap,
         mode::{ConvertError, IGameMode},
@@ -52,6 +53,13 @@ impl IGameMode for Catch {
         map: &Beatmap,
     ) -> Result<Self::DifficultyAttributes, ConvertError> {
         difficulty::difficulty(difficulty, map)
+    }
+
+    fn checked_difficulty(
+        difficulty: &Difficulty,
+        map: &Beatmap,
+    ) -> Result<Self::DifficultyAttributes, CalculateError> {
+        difficulty::checked_difficulty(difficulty, map)
     }
 
     fn strains(difficulty: &Difficulty, map: &Beatmap) -> Result<Self::Strains, ConvertError> {

--- a/src/catch/performance/gradual.rs
+++ b/src/catch/performance/gradual.rs
@@ -1,5 +1,6 @@
 use crate::{
     Beatmap, Difficulty,
+    any::CalculateError,
     catch::{CatchGradualDifficulty, CatchPerformanceAttributes, CatchScoreState},
     model::mode::ConvertError,
 };
@@ -91,6 +92,14 @@ impl CatchGradualPerformance {
     /// Create a new gradual performance calculator for osu!catch maps.
     pub fn new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, ConvertError> {
         let difficulty = CatchGradualDifficulty::new(difficulty, map)?;
+
+        Ok(Self { difficulty })
+    }
+
+    /// Same as [`CatchGradualPerformance::new`] but verifies that the map is
+    /// not suspicious.
+    pub fn checked_new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, CalculateError> {
+        let difficulty = CatchGradualDifficulty::checked_new(difficulty, map)?;
 
         Ok(Self { difficulty })
     }

--- a/src/catch/performance/mod.rs
+++ b/src/catch/performance/mod.rs
@@ -5,8 +5,8 @@ use self::calculator::CatchPerformanceCalculator;
 use crate::{
     Performance,
     any::{
-        Difficulty, HitResultGenerator, InspectablePerformance, IntoModePerformance,
-        IntoPerformance, hitresult_generator::Fast,
+        CalculateError, Difficulty, HitResultGenerator, InspectablePerformance,
+        IntoModePerformance, IntoPerformance, hitresult_generator::Fast,
     },
     catch::{CatchHitResults, performance::inspect::InspectCatchPerformance},
     model::{mode::ConvertError, mods::GameMods},
@@ -320,52 +320,51 @@ impl<'map> CatchPerformance<'map> {
         self
     }
 
-    /// Create the [`CatchScoreState`] that will be used for performance calculation.
+    /// Create the [`CatchScoreState`] that will be used for performance
+    /// calculation.
+    ///
+    /// If this [`CatchPerformance`] contained a [`Beatmap`], it will be
+    /// replaced by [`CatchDifficultyAttributes`].
+    ///
+    /// [`Beatmap`]: crate::Beatmap
+    /// [`CatchDifficultyAttributes`]: crate::catch::CatchDifficultyAttributes
     pub fn generate_state(&mut self) -> Result<CatchScoreState, ConvertError> {
         self.map_or_attrs.insert_attrs(&self.difficulty)?;
 
         // SAFETY: We just calculated and inserted the attributes.
-        let attrs = unsafe { self.map_or_attrs.get_attrs() };
+        let state = unsafe { generate_state(self) };
 
-        let inspect = Catch::inspect_performance(self, attrs);
+        Ok(state)
+    }
 
-        let misses = inspect.misses();
-        let max_combo = self.combo.unwrap_or_else(|| attrs.max_combo() - misses);
+    /// Same as [`CatchPerformance::generate_state`] but verifies that the map
+    /// was not suspicious.
+    pub fn checked_generate_state(&mut self) -> Result<CatchScoreState, CalculateError> {
+        self.map_or_attrs.checked_insert_attrs(&self.difficulty)?;
 
-        let hitresults = match self.hitresult_generator {
-            Some(generator) => generator(inspect),
-            None => <Fast as HitResultGenerator<Catch>>::generate_hitresults(inspect),
-        };
+        // SAFETY: We just calculated and inserted the attributes.
+        let state = unsafe { generate_state(self) };
 
-        let CatchHitResults {
-            fruits,
-            droplets,
-            tiny_droplets,
-            tiny_droplet_misses,
-            misses,
-        } = hitresults;
-
-        self.combo = Some(max_combo);
-        self.fruits = Some(fruits);
-        self.droplets = Some(droplets);
-        self.tiny_droplets = Some(tiny_droplets);
-        self.tiny_droplet_misses = Some(tiny_droplet_misses);
-        self.misses = Some(misses);
-
-        Ok(CatchScoreState {
-            max_combo,
-            hitresults,
-        })
+        Ok(state)
     }
 
     /// Calculate all performance related values, including pp and stars.
     pub fn calculate(mut self) -> Result<CatchPerformanceAttributes, ConvertError> {
         let state = self.generate_state()?;
 
-        let attrs = match self.map_or_attrs {
-            MapOrAttrs::Attrs(attrs) => attrs,
-            MapOrAttrs::Map(ref map) => self.difficulty.calculate_for_mode::<Catch>(map)?,
-        };
+        // SAFETY: Attributes are calculated in `generate_state`.
+        let attrs = unsafe { self.map_or_attrs.into_attrs() };
+
+        Ok(CatchPerformanceCalculator::new(attrs, self.difficulty.get_mods(), state).calculate())
+    }
+
+    /// Same as [`CatchPerformance::calculate`] but verifies that the map was
+    /// not suspicious.
+    pub fn checked_calculate(mut self) -> Result<CatchPerformanceAttributes, CalculateError> {
+        let state = self.checked_generate_state()?;
+
+        // SAFETY: Attributes are calculated in `checked_generate_state`.
+        let attrs = unsafe { self.map_or_attrs.into_attrs() };
 
         Ok(CatchPerformanceCalculator::new(attrs, self.difficulty.get_mods(), state).calculate())
     }
@@ -441,6 +440,43 @@ impl<'map> TryFrom<OsuPerformance<'map>> for CatchPerformance<'map> {
 impl<'map, T: IntoModePerformance<'map, Catch>> From<T> for CatchPerformance<'map> {
     fn from(into: T) -> Self {
         into.into_performance()
+    }
+}
+
+/// # Safety
+/// Caller must ensure that the internal [`MapOrAttrs`] contains attributes.
+unsafe fn generate_state(perf: &mut CatchPerformance) -> CatchScoreState {
+    // SAFETY: Ensured by caller
+    let attrs = unsafe { perf.map_or_attrs.get_attrs() };
+
+    let inspect = Catch::inspect_performance(perf, attrs);
+
+    let misses = inspect.misses();
+    let max_combo = perf.combo.unwrap_or_else(|| attrs.max_combo() - misses);
+
+    let hitresults = match perf.hitresult_generator {
+        Some(generator) => generator(inspect),
+        None => <Fast as HitResultGenerator<Catch>>::generate_hitresults(inspect),
+    };
+
+    let CatchHitResults {
+        fruits,
+        droplets,
+        tiny_droplets,
+        tiny_droplet_misses,
+        misses,
+    } = hitresults;
+
+    perf.combo = Some(max_combo);
+    perf.fruits = Some(fruits);
+    perf.droplets = Some(droplets);
+    perf.tiny_droplets = Some(tiny_droplets);
+    perf.tiny_droplet_misses = Some(tiny_droplet_misses);
+    perf.misses = Some(misses);
+
+    CatchScoreState {
+        max_combo,
+        hitresults,
     }
 }
 

--- a/src/mania/difficulty/gradual.rs
+++ b/src/mania/difficulty/gradual.rs
@@ -4,8 +4,8 @@ use rosu_map::section::general::GameMode;
 
 use crate::{
     Beatmap, Difficulty,
-    any::difficulty::skills::StrainSkill,
-    mania::{convert, object::ObjectParams},
+    any::{CalculateError, difficulty::skills::StrainSkill},
+    mania::object::ObjectParams,
     model::{hit_object::HitObject, mode::ConvertError},
     util::sync::RefCount,
 };
@@ -66,67 +66,66 @@ struct NoteState {
 impl ManiaGradualDifficulty {
     /// Create a new difficulty attributes iterator for osu!mania maps.
     pub fn new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, ConvertError> {
-        let mut map = map.convert_ref(GameMode::Mania, difficulty.get_mods())?;
+        let map = super::prepare_map(&difficulty, map)?;
 
-        if difficulty.get_mods().ho() {
-            convert::apply_hold_off_to_beatmap(map.to_mut());
-        }
+        Ok(new(difficulty, &map))
+    }
 
-        if difficulty.get_mods().invert() {
-            convert::apply_invert_to_beatmap(map.to_mut());
-        }
+    /// Same as [`ManiaGradualDifficulty::new`] but verifies that the map is not
+    /// suspicious.
+    pub fn checked_new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, CalculateError> {
+        let map = super::prepare_map(&difficulty, map)?;
+        map.check_suspicion()?;
 
-        if let Some(seed) = difficulty.get_mods().random_seed() {
-            convert::apply_random_to_beatmap(map.to_mut(), seed);
-        }
+        Ok(new(difficulty, &map))
+    }
+}
 
-        let map = map.to_mut();
-        map.mania_hitobjects_legacy_sort();
+fn new(difficulty: Difficulty, map: &Beatmap) -> ManiaGradualDifficulty {
+    debug_assert_eq!(map.mode, GameMode::Mania);
 
-        let take = difficulty.get_passed_objects();
-        let total_columns = map.cs.round_ties_even().max(1.0);
-        let clock_rate = difficulty.get_clock_rate();
-        let mut params = ObjectParams::new(map);
+    let take = difficulty.get_passed_objects();
+    let total_columns = map.cs.round_ties_even().max(1.0);
+    let clock_rate = difficulty.get_clock_rate();
+    let mut params = ObjectParams::new(map);
 
-        let mania_objects = map
-            .hit_objects
-            .iter()
-            .map(|h| ManiaObject::new(h, total_columns, &mut params))
-            .take(take);
+    let mania_objects = map
+        .hit_objects
+        .iter()
+        .map(|h| ManiaObject::new(h, total_columns, &mut params))
+        .take(take);
 
-        let diff_objects = DifficultyValues::create_difficulty_objects(
-            clock_rate,
-            total_columns as usize,
-            mania_objects,
+    let diff_objects = DifficultyValues::create_difficulty_objects(
+        clock_rate,
+        total_columns as usize,
+        mania_objects,
+    );
+
+    let strain = Strain::new(total_columns as usize);
+
+    let mut note_state = NoteState::default();
+
+    let objects_is_circle: Box<[_]> = map.hit_objects.iter().map(HitObject::is_circle).collect();
+
+    if let Some(h) = map.hit_objects.first() {
+        let hit_object = ManiaObject::new(h, total_columns, &mut params);
+
+        increment_combo_raw(
+            objects_is_circle[0],
+            hit_object.start_time,
+            hit_object.end_time,
+            &mut note_state,
         );
+    }
 
-        let strain = Strain::new(total_columns as usize);
-
-        let mut note_state = NoteState::default();
-
-        let objects_is_circle: Box<[_]> =
-            map.hit_objects.iter().map(HitObject::is_circle).collect();
-
-        if let Some(h) = map.hit_objects.first() {
-            let hit_object = ManiaObject::new(h, total_columns, &mut params);
-
-            increment_combo_raw(
-                objects_is_circle[0],
-                hit_object.start_time,
-                hit_object.end_time,
-                &mut note_state,
-            );
-        }
-
-        Ok(Self {
-            idx: 0,
-            difficulty,
-            objects_is_circle,
-            is_convert: map.is_convert,
-            strain,
-            diff_objects,
-            note_state,
-        })
+    ManiaGradualDifficulty {
+        idx: 0,
+        difficulty,
+        objects_is_circle,
+        is_convert: map.is_convert,
+        strain,
+        diff_objects,
+        note_state,
     }
 }
 

--- a/src/mania/difficulty/mod.rs
+++ b/src/mania/difficulty/mod.rs
@@ -1,10 +1,13 @@
-use std::cmp;
+use std::{borrow::Cow, cmp};
 
 use rosu_map::section::general::GameMode;
 
 use crate::{
     Beatmap,
-    any::difficulty::{Difficulty, skills::StrainSkill},
+    any::{
+        CalculateError,
+        difficulty::{Difficulty, skills::StrainSkill},
+    },
     mania::{
         difficulty::{object::ManiaDifficultyObject, skills::strain::Strain},
         object::{ManiaObject, ObjectParams},
@@ -26,6 +29,25 @@ pub fn difficulty(
     difficulty: &Difficulty,
     map: &Beatmap,
 ) -> Result<ManiaDifficultyAttributes, ConvertError> {
+    let map = prepare_map(difficulty, map)?;
+
+    Ok(calculate_difficulty(difficulty, &map))
+}
+
+pub fn checked_difficulty(
+    difficulty: &Difficulty,
+    map: &Beatmap,
+) -> Result<ManiaDifficultyAttributes, CalculateError> {
+    let map = prepare_map(difficulty, map)?;
+    map.check_suspicion()?;
+
+    Ok(calculate_difficulty(difficulty, &map))
+}
+
+fn prepare_map<'map>(
+    difficulty: &Difficulty,
+    map: &'map Beatmap,
+) -> Result<Cow<'map, Beatmap>, ConvertError> {
     let mut map = map.convert_ref(GameMode::Mania, difficulty.get_mods())?;
 
     if difficulty.get_mods().ho() {
@@ -40,20 +62,26 @@ pub fn difficulty(
         convert::apply_random_to_beatmap(map.to_mut(), seed);
     }
 
-    let map = map.to_mut();
-    map.mania_hitobjects_legacy_sort();
+    let map_mut = map.to_mut();
+    map_mut.mania_hitobjects_legacy_sort();
+
+    Ok(map)
+}
+
+fn calculate_difficulty(difficulty: &Difficulty, map: &Beatmap) -> ManiaDifficultyAttributes {
+    debug_assert_eq!(map.mode, GameMode::Mania);
 
     let n_objects = cmp::min(difficulty.get_passed_objects(), map.hit_objects.len()) as u32;
 
     let values = DifficultyValues::calculate(difficulty, map);
 
-    Ok(ManiaDifficultyAttributes {
+    ManiaDifficultyAttributes {
         stars: values.strain.into_difficulty_value() * DIFFICULTY_MULTIPLIER,
         max_combo: values.max_combo,
         n_objects,
         n_hold_notes: values.n_hold_notes,
         is_convert: map.is_convert,
-    })
+    }
 }
 
 pub struct DifficultyValues {

--- a/src/mania/mod.rs
+++ b/src/mania/mod.rs
@@ -2,6 +2,7 @@ use rosu_map::section::general::GameMode;
 
 use crate::{
     Difficulty, GameMods,
+    any::CalculateError,
     model::{
         beatmap::Beatmap,
         mode::{ConvertError, IGameMode},
@@ -49,6 +50,13 @@ impl IGameMode for Mania {
         map: &Beatmap,
     ) -> Result<Self::DifficultyAttributes, ConvertError> {
         difficulty::difficulty(difficulty, map)
+    }
+
+    fn checked_difficulty(
+        difficulty: &Difficulty,
+        map: &Beatmap,
+    ) -> Result<Self::DifficultyAttributes, CalculateError> {
+        difficulty::checked_difficulty(difficulty, map)
     }
 
     fn strains(difficulty: &Difficulty, map: &Beatmap) -> Result<Self::Strains, ConvertError> {

--- a/src/mania/performance/gradual.rs
+++ b/src/mania/performance/gradual.rs
@@ -1,4 +1,7 @@
-use crate::{Beatmap, Difficulty, mania::ManiaGradualDifficulty, model::mode::ConvertError};
+use crate::{
+    Beatmap, Difficulty, any::CalculateError, mania::ManiaGradualDifficulty,
+    model::mode::ConvertError,
+};
 
 use super::{ManiaPerformanceAttributes, ManiaScoreState};
 
@@ -72,6 +75,14 @@ impl ManiaGradualPerformance {
     /// Create a new gradual performance calculator for osu!mania maps.
     pub fn new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, ConvertError> {
         let difficulty = ManiaGradualDifficulty::new(difficulty, map)?;
+
+        Ok(Self { difficulty })
+    }
+
+    /// Same as [`ManiaGradualPerformance::new`] but verifies that the map is
+    /// not suspicious.
+    pub fn checked_new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, CalculateError> {
+        let difficulty = ManiaGradualDifficulty::checked_new(difficulty, map)?;
 
         Ok(Self { difficulty })
     }

--- a/src/mania/performance/mod.rs
+++ b/src/mania/performance/mod.rs
@@ -7,7 +7,7 @@ pub use self::inspect::InspectManiaPerformance;
 use crate::{
     Performance,
     any::{
-        Difficulty, HitResultGenerator, HitResultPriority, InspectablePerformance,
+        CalculateError, Difficulty, HitResultGenerator, HitResultPriority, InspectablePerformance,
         IntoModePerformance, IntoPerformance, hitresult_generator::Fast,
     },
     mania::ManiaHitResults,
@@ -302,73 +302,51 @@ impl<'map> ManiaPerformance<'map> {
         self
     }
 
-    /// Create the [`ManiaScoreState`] that will be used for performance calculation.
+    /// Create the [`ManiaScoreState`] that will be used for performance
+    /// calculation.
+    ///
+    /// If this [`ManiaPerformance`] contained a [`Beatmap`], it will be
+    /// replaced by [`ManiaDifficultyAttributes`].
+    ///
+    /// [`Beatmap`]: crate::Beatmap
+    /// [`ManiaDifficultyAttributes`]: crate::mania::ManiaDifficultyAttributes
     pub fn generate_state(&mut self) -> Result<ManiaScoreState, ConvertError> {
         self.map_or_attrs.insert_attrs(&self.difficulty)?;
 
         // SAFETY: We just calculated and inserted the attributes.
-        let attrs = unsafe { self.map_or_attrs.get_attrs() };
+        let state = unsafe { generate_state(self) };
 
-        let inspect = Mania::inspect_performance(self, attrs);
+        Ok(state)
+    }
 
-        let total_hits = inspect.total_hits();
+    /// Same as [`ManiaPerformance::generate_state`] but verifies that the map
+    /// was not suspicious.
+    pub fn checked_generate_state(&mut self) -> Result<ManiaScoreState, CalculateError> {
+        self.map_or_attrs.checked_insert_attrs(&self.difficulty)?;
 
-        let mut hitresults = match self.hitresult_generator {
-            Some(generator) => generator(inspect),
-            // TODO: use Statistical(?)
-            None => <Fast as HitResultGenerator<Mania>>::generate_hitresults(inspect),
-        };
+        // SAFETY: We just calculated and inserted the attributes.
+        let state = unsafe { generate_state(self) };
 
-        let remain = total_hits.saturating_sub(hitresults.total_hits());
-
-        match self.hitresult_priority {
-            HitResultPriority::BestCase => {
-                match (self.n320, self.n300, self.n200, self.n100, self.n50) {
-                    (None, ..) => hitresults.n320 += remain,
-                    (_, None, ..) => hitresults.n300 += remain,
-                    (_, _, None, ..) => hitresults.n200 += remain,
-                    (.., None, _) => hitresults.n100 += remain,
-                    _ => hitresults.n50 += remain,
-                }
-            }
-            HitResultPriority::WorstCase => {
-                match (self.n50, self.n100, self.n200, self.n300, self.n320) {
-                    (None, ..) => hitresults.n50 += remain,
-                    (_, None, ..) => hitresults.n100 += remain,
-                    (_, _, None, ..) => hitresults.n200 += remain,
-                    (.., None, _) => hitresults.n300 += remain,
-                    _ => hitresults.n320 += remain,
-                }
-            }
-        }
-
-        let ManiaHitResults {
-            n320,
-            n300,
-            n200,
-            n100,
-            n50,
-            misses,
-        } = &hitresults;
-
-        self.n320 = Some(*n320);
-        self.n300 = Some(*n300);
-        self.n200 = Some(*n200);
-        self.n100 = Some(*n100);
-        self.n50 = Some(*n50);
-        self.misses = Some(*misses);
-
-        Ok(hitresults)
+        Ok(state)
     }
 
     /// Calculate all performance related values, including pp and stars.
     pub fn calculate(mut self) -> Result<ManiaPerformanceAttributes, ConvertError> {
         let state = self.generate_state()?;
 
-        let attrs = match self.map_or_attrs {
-            MapOrAttrs::Attrs(attrs) => attrs,
-            MapOrAttrs::Map(ref map) => self.difficulty.calculate_for_mode::<Mania>(map)?,
-        };
+        // SAFETY: Attributes are calculated in `generate_state`.
+        let attrs = unsafe { self.map_or_attrs.into_attrs() };
+
+        Ok(ManiaPerformanceCalculator::new(attrs, self.difficulty.get_mods(), state).calculate())
+    }
+
+    /// Same as [`ManiaPerformance::calculate`] but verifies that the map was
+    /// not suspicious.
+    pub fn checked_calculate(mut self) -> Result<ManiaPerformanceAttributes, CalculateError> {
+        let state = self.checked_generate_state()?;
+
+        // SAFETY: Attributes are calculated in `checked_generate_state`.
+        let attrs = unsafe { self.map_or_attrs.into_attrs() };
 
         Ok(ManiaPerformanceCalculator::new(attrs, self.difficulty.get_mods(), state).calculate())
     }
@@ -447,6 +425,64 @@ impl<'map, T: IntoModePerformance<'map, Mania>> From<T> for ManiaPerformance<'ma
     fn from(into: T) -> Self {
         into.into_performance()
     }
+}
+
+/// # Safety
+/// Caller must ensure that the internal [`MapOrAttrs`] contains attributes.
+unsafe fn generate_state(perf: &mut ManiaPerformance) -> ManiaScoreState {
+    // SAFETY: Ensured by caller
+    let attrs = unsafe { perf.map_or_attrs.get_attrs() };
+
+    let inspect = Mania::inspect_performance(perf, attrs);
+
+    let total_hits = inspect.total_hits();
+
+    let mut hitresults = match perf.hitresult_generator {
+        Some(generator) => generator(inspect),
+        // TODO: use Statistical(?)
+        None => <Fast as HitResultGenerator<Mania>>::generate_hitresults(inspect),
+    };
+
+    let remain = total_hits.saturating_sub(hitresults.total_hits());
+
+    match perf.hitresult_priority {
+        HitResultPriority::BestCase => {
+            match (perf.n320, perf.n300, perf.n200, perf.n100, perf.n50) {
+                (None, ..) => hitresults.n320 += remain,
+                (_, None, ..) => hitresults.n300 += remain,
+                (_, _, None, ..) => hitresults.n200 += remain,
+                (.., None, _) => hitresults.n100 += remain,
+                _ => hitresults.n50 += remain,
+            }
+        }
+        HitResultPriority::WorstCase => {
+            match (perf.n50, perf.n100, perf.n200, perf.n300, perf.n320) {
+                (None, ..) => hitresults.n50 += remain,
+                (_, None, ..) => hitresults.n100 += remain,
+                (_, _, None, ..) => hitresults.n200 += remain,
+                (.., None, _) => hitresults.n300 += remain,
+                _ => hitresults.n320 += remain,
+            }
+        }
+    }
+
+    let ManiaHitResults {
+        n320,
+        n300,
+        n200,
+        n100,
+        n50,
+        misses,
+    } = &hitresults;
+
+    perf.n320 = Some(*n320);
+    perf.n300 = Some(*n300);
+    perf.n200 = Some(*n200);
+    perf.n100 = Some(*n100);
+    perf.n50 = Some(*n50);
+    perf.misses = Some(*misses);
+
+    hitresults
 }
 
 #[cfg(test)]

--- a/src/model/beatmap/suspicious.rs
+++ b/src/model/beatmap/suspicious.rs
@@ -17,7 +17,7 @@ use super::Beatmap;
 ///
 /// [`Beatmap::check_suspicion`]: crate::model::beatmap::Beatmap::check_suspicion
 /// [`Beatmap`]: crate::model::beatmap::Beatmap
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 pub enum TooSuspicious {
     /// Notes are too dense time-wise.

--- a/src/model/mode.rs
+++ b/src/model/mode.rs
@@ -5,7 +5,7 @@ use std::{
 
 pub use rosu_map::section::general::GameMode;
 
-use crate::Difficulty;
+use crate::{Difficulty, any::CalculateError};
 
 use super::beatmap::Beatmap;
 
@@ -43,6 +43,13 @@ pub trait IGameMode: Sized {
         difficulty: &Difficulty,
         map: &Beatmap,
     ) -> Result<Self::DifficultyAttributes, ConvertError>;
+
+    /// Same as [`IGameMode::difficulty`] but verifies that the [`Beatmap`] is
+    /// not too suspicious for further calculation.
+    fn checked_difficulty(
+        difficulty: &Difficulty,
+        map: &Beatmap,
+    ) -> Result<Self::DifficultyAttributes, CalculateError>;
 
     /// Perform a difficulty calculation for a [`Beatmap`] without processing
     /// the final skill values.

--- a/src/osu/difficulty/gradual.rs
+++ b/src/osu/difficulty/gradual.rs
@@ -4,7 +4,7 @@ use rosu_map::section::general::GameMode;
 
 use crate::{
     Beatmap, Difficulty,
-    any::difficulty::skills::StrainSkill,
+    any::{CalculateError, difficulty::skills::StrainSkill},
     model::mode::ConvertError,
     osu::{
         convert::convert_objects,
@@ -77,62 +77,18 @@ struct NotClonable;
 impl OsuGradualDifficulty {
     /// Create a new difficulty attributes iterator for osu!standard maps.
     pub fn new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, ConvertError> {
-        let mods = difficulty.get_mods();
-        let map = map.convert_ref(GameMode::Osu, mods)?;
+        let map = super::prepare_map(&difficulty, map)?;
 
-        let OsuDifficultySetup {
-            scaling_factor,
-            map_attrs,
-            mut attrs,
-            time_preempt,
-        } = OsuDifficultySetup::new(&difficulty, &map);
+        Ok(new(difficulty, &map))
+    }
 
-        let osu_objects = convert_objects(
-            &map,
-            &scaling_factor,
-            mods.reflection(),
-            time_preempt,
-            map.hit_objects.len(),
-            &mut attrs,
-        );
+    /// Same as [`OsuGradualDifficulty::new`] but verifies that the map is not
+    /// suspicious.
+    pub fn checked_new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, CalculateError> {
+        let map = super::prepare_map(&difficulty, map)?;
+        map.check_suspicion()?;
 
-        attrs.n_circles = 0;
-        attrs.n_sliders = 0;
-        attrs.n_large_ticks = 0;
-        attrs.n_spinners = 0;
-        attrs.max_combo = 0;
-
-        if let Some(h) = osu_objects.first() {
-            Self::increment_combo(h, &mut attrs);
-        }
-
-        let mut osu_objects = OsuObjects::new(osu_objects);
-
-        let diff_objects = DifficultyValues::create_difficulty_objects(
-            &difficulty,
-            &scaling_factor,
-            osu_objects.iter_mut(),
-        );
-
-        let great_hit_window = map_attrs.hit_windows().od_great.unwrap_or(0.0);
-
-        let skills = OsuSkills::new(mods, &scaling_factor, great_hit_window, time_preempt);
-        let diff_objects = extend_lifetime(diff_objects.into_boxed_slice());
-
-        let score_simulator = GradualLegacyScoreSimulator::new(&map, map_attrs);
-        let nested_score = GradualNestedScorePerObject::default();
-
-        Ok(Self {
-            idx: 0,
-            difficulty,
-            attrs,
-            skills,
-            diff_objects,
-            osu_objects,
-            score_simulator: Box::new(score_simulator),
-            nested_score,
-            _not_clonable: NotClonable,
-        })
+        Ok(new(difficulty, &map))
     }
 
     fn increment_combo(h: &OsuObject, attrs: &mut OsuDifficultyAttributes) {
@@ -147,6 +103,66 @@ impl OsuGradualDifficulty {
             }
             OsuObjectKind::Spinner { .. } => attrs.n_spinners += 1,
         }
+    }
+}
+
+fn new(difficulty: Difficulty, map: &Beatmap) -> OsuGradualDifficulty {
+    debug_assert_eq!(map.mode, GameMode::Osu);
+
+    let mods = difficulty.get_mods();
+
+    let OsuDifficultySetup {
+        scaling_factor,
+        map_attrs,
+        mut attrs,
+        time_preempt,
+    } = OsuDifficultySetup::new(&difficulty, map);
+
+    let osu_objects = convert_objects(
+        map,
+        &scaling_factor,
+        mods.reflection(),
+        time_preempt,
+        map.hit_objects.len(),
+        &mut attrs,
+    );
+
+    attrs.n_circles = 0;
+    attrs.n_sliders = 0;
+    attrs.n_large_ticks = 0;
+    attrs.n_spinners = 0;
+    attrs.max_combo = 0;
+
+    if let Some(h) = osu_objects.first() {
+        OsuGradualDifficulty::increment_combo(h, &mut attrs);
+    }
+
+    let mut osu_objects = OsuObjects::new(osu_objects);
+
+    let diff_objects = DifficultyValues::create_difficulty_objects(
+        &difficulty,
+        &scaling_factor,
+        osu_objects.iter_mut(),
+    );
+
+    let great_hit_window = map_attrs.hit_windows().od_great.unwrap_or(0.0);
+
+    let skills = OsuSkills::new(mods, &scaling_factor, great_hit_window, time_preempt);
+    let diff_objects = extend_lifetime(diff_objects.into_boxed_slice());
+
+    let score_simulator = GradualLegacyScoreSimulator::new(map, map_attrs);
+    let nested_score = GradualNestedScorePerObject::default();
+
+    OsuGradualDifficulty {
+        idx: 0,
+        difficulty,
+        attrs,
+        skills,
+        diff_objects,
+        osu_objects,
+        score_simulator: Box::new(score_simulator),
+        nested_score,
+        _not_clonable: NotClonable,
     }
 }
 

--- a/src/osu/difficulty/mod.rs
+++ b/src/osu/difficulty/mod.rs
@@ -1,11 +1,14 @@
-use std::{cmp, pin::Pin};
+use std::{borrow::Cow, cmp, pin::Pin};
 
 use rosu_map::section::general::GameMode;
 use skills::{aim::Aim, flashlight::Flashlight, speed::Speed, strain::OsuStrainSkill};
 
 use crate::{
     Beatmap,
-    any::difficulty::{Difficulty, skills::StrainSkill},
+    any::{
+        CalculateError,
+        difficulty::{Difficulty, skills::StrainSkill},
+    },
     model::{beatmap::BeatmapAttributes, mode::ConvertError, mods::GameMods},
     osu::{
         convert::convert_objects,
@@ -40,20 +43,43 @@ pub fn difficulty(
     difficulty: &Difficulty,
     map: &Beatmap,
 ) -> Result<OsuDifficultyAttributes, ConvertError> {
-    let map = map.convert_ref(GameMode::Osu, difficulty.get_mods())?;
+    let map = prepare_map(difficulty, map)?;
+
+    Ok(calculate_difficulty(difficulty, &map))
+}
+
+pub fn checked_difficulty(
+    difficulty: &Difficulty,
+    map: &Beatmap,
+) -> Result<OsuDifficultyAttributes, CalculateError> {
+    let map = prepare_map(difficulty, map)?;
+    map.check_suspicion()?;
+
+    Ok(calculate_difficulty(difficulty, &map))
+}
+
+fn prepare_map<'map>(
+    difficulty: &Difficulty,
+    map: &'map Beatmap,
+) -> Result<Cow<'map, Beatmap>, ConvertError> {
+    map.convert_ref(GameMode::Osu, difficulty.get_mods())
+}
+
+fn calculate_difficulty(difficulty: &Difficulty, map: &Beatmap) -> OsuDifficultyAttributes {
+    debug_assert_eq!(map.mode, GameMode::Osu);
 
     let DifficultyValues {
         osu_objects,
         skills,
         mut attrs,
-    } = DifficultyValues::calculate(difficulty, &map);
+    } = DifficultyValues::calculate(difficulty, map);
 
     let mods = difficulty.get_mods();
     let passed_objects = difficulty.get_passed_objects();
 
     DifficultyValues::eval(&mut attrs, mods, &skills);
 
-    let mut simulator = OsuLegacyScoreSimulator::new(&osu_objects, &map, passed_objects);
+    let mut simulator = OsuLegacyScoreSimulator::new(&osu_objects, map, passed_objects);
 
     let score_attrs = simulator.simulate();
     attrs.maximum_legacy_combo_score = score_attrs.combo_score as f64;
@@ -61,7 +87,7 @@ pub fn difficulty(
     let map_attrs = map.attributes().difficulty(difficulty).build();
 
     attrs.legacy_score_base_multiplier = f64::from(OsuLegacyScoreSimulator::score_multiplier(
-        &map,
+        map,
         &map_attrs,
         passed_objects,
     ));
@@ -70,7 +96,7 @@ pub fn difficulty(
         NestedScorePerObject::calculate(&osu_objects, passed_objects);
     attrs.nested_score_per_object = slider_nested_score_per_object;
 
-    Ok(attrs)
+    attrs
 }
 
 pub struct OsuDifficultySetup {

--- a/src/osu/mod.rs
+++ b/src/osu/mod.rs
@@ -2,6 +2,7 @@ use rosu_map::util::Pos;
 
 use crate::{
     Difficulty,
+    any::CalculateError,
     model::{
         beatmap::Beatmap,
         mode::{ConvertError, IGameMode},
@@ -47,6 +48,13 @@ impl IGameMode for Osu {
         map: &Beatmap,
     ) -> Result<Self::DifficultyAttributes, ConvertError> {
         difficulty::difficulty(difficulty, map)
+    }
+
+    fn checked_difficulty(
+        difficulty: &Difficulty,
+        map: &Beatmap,
+    ) -> Result<Self::DifficultyAttributes, CalculateError> {
+        difficulty::checked_difficulty(difficulty, map)
     }
 
     fn strains(difficulty: &Difficulty, map: &Beatmap) -> Result<Self::Strains, ConvertError> {

--- a/src/osu/performance/gradual.rs
+++ b/src/osu/performance/gradual.rs
@@ -1,4 +1,6 @@
-use crate::{Beatmap, Difficulty, model::mode::ConvertError, osu::OsuGradualDifficulty};
+use crate::{
+    Beatmap, Difficulty, any::CalculateError, model::mode::ConvertError, osu::OsuGradualDifficulty,
+};
 
 use super::{OsuPerformanceAttributes, OsuScoreState};
 
@@ -84,6 +86,15 @@ impl OsuGradualPerformance {
     pub fn new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, ConvertError> {
         let lazer = difficulty.get_lazer();
         let difficulty = OsuGradualDifficulty::new(difficulty, map)?;
+
+        Ok(Self { lazer, difficulty })
+    }
+
+    /// Same as [`OsuGradualPerformance::new`] but verifies that the map is
+    /// not suspicious.
+    pub fn checked_new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, CalculateError> {
+        let lazer = difficulty.get_lazer();
+        let difficulty = OsuGradualDifficulty::checked_new(difficulty, map)?;
 
         Ok(Self { lazer, difficulty })
     }

--- a/src/osu/performance/mod.rs
+++ b/src/osu/performance/mod.rs
@@ -9,7 +9,7 @@ pub use self::{calculator::PERFORMANCE_BASE_MULTIPLIER, inspect::InspectOsuPerfo
 use crate::{
     Beatmap,
     any::{
-        Difficulty, HitResultGenerator, HitResultPriority, InspectablePerformance,
+        CalculateError, Difficulty, HitResultGenerator, HitResultPriority, InspectablePerformance,
         IntoModePerformance, IntoPerformance, Performance, hitresult_generator::Fast,
     },
     catch::CatchPerformance,
@@ -447,104 +447,53 @@ impl<'map> OsuPerformance<'map> {
         self
     }
 
-    /// Create the [`OsuScoreState`] that will be used for performance calculation.
+    /// Create the [`OsuScoreState`] that will be used for performance
+    /// calculation.
+    ///
+    /// If this [`OsuPerformance`] contained a [`Beatmap`], it will be replaced
+    /// by [`OsuDifficultyAttributes`].
+    ///
+    /// [`Beatmap`]: crate::Beatmap
+    /// [`OsuDifficultyAttributes`]: crate::osu::OsuDifficultyAttributes
     pub fn generate_state(&mut self) -> Result<OsuScoreState, ConvertError> {
         self.map_or_attrs.insert_attrs(&self.difficulty)?;
 
         // SAFETY: We just calculated and inserted the attributes.
-        let attrs = unsafe { self.map_or_attrs.get_attrs() };
+        let state = unsafe { generate_state(self) };
 
-        let inspect = Osu::inspect_performance(self, attrs);
+        Ok(state)
+    }
 
-        let total_hits = inspect.total_hits();
-        let misses = inspect.misses();
+    /// Same as [`OsuPerformance::generate_state`] but verifies that the map
+    /// was not suspicious.
+    pub fn checked_generate_state(&mut self) -> Result<OsuScoreState, CalculateError> {
+        self.map_or_attrs.checked_insert_attrs(&self.difficulty)?;
 
-        let mut hitresults = match self.hitresult_generator {
-            Some(generator) => generator(inspect),
-            None => <Fast as HitResultGenerator<Osu>>::generate_hitresults(inspect),
-        };
+        // SAFETY: We just calculated and inserted the attributes.
+        let state = unsafe { generate_state(self) };
 
-        let remain = total_hits.saturating_sub(hitresults.total_hits());
-
-        match self.hitresult_priority {
-            HitResultPriority::BestCase => match (self.n300, self.n100, self.n50) {
-                (None, ..) => hitresults.n300 += remain,
-                (_, None, _) => hitresults.n100 += remain,
-                (.., None) => hitresults.n50 += remain,
-                _ => hitresults.n300 += remain,
-            },
-            HitResultPriority::WorstCase => match (self.n50, self.n100, self.n300) {
-                (None, ..) => hitresults.n50 += remain,
-                (_, None, _) => hitresults.n100 += remain,
-                (.., None) => hitresults.n300 += remain,
-                _ => hitresults.n50 += remain,
-            },
-        }
-
-        let max_possible_combo = attrs.max_combo.saturating_sub(misses);
-
-        let max_combo = self.combo.map_or(max_possible_combo, |combo| {
-            cmp::min(combo, max_possible_combo)
-        });
-
-        self.combo = Some(max_combo);
-
-        let OsuHitResults {
-            large_tick_hits,
-            small_tick_hits,
-            slider_end_hits,
-            n300,
-            n100,
-            n50,
-            misses,
-        } = &hitresults;
-
-        self.slider_end_hits = Some(*slider_end_hits);
-        self.large_tick_hits = Some(*large_tick_hits);
-        self.small_tick_hits = Some(*small_tick_hits);
-        self.n300 = Some(*n300);
-        self.n100 = Some(*n100);
-        self.n50 = Some(*n50);
-        self.misses = Some(*misses);
-
-        Ok(OsuScoreState {
-            max_combo,
-            hitresults,
-            legacy_total_score: self.legacy_total_score,
-        })
+        Ok(state)
     }
 
     /// Calculate all performance related values, including pp and stars.
     pub fn calculate(mut self) -> Result<OsuPerformanceAttributes, ConvertError> {
         let state = self.generate_state()?;
 
-        let attrs = match self.map_or_attrs {
-            MapOrAttrs::Attrs(attrs) => attrs,
-            MapOrAttrs::Map(ref map) => self.difficulty.calculate_for_mode::<Osu>(map)?,
-        };
+        // SAFETY: Attributes are calculated in `generate_state`.
+        let attrs = unsafe { calculate(self, state) };
 
-        let mods = self.difficulty.get_mods();
-        let lazer = self.difficulty.get_lazer();
-        let using_classic_slider_acc = mods.no_slider_head_acc(lazer);
+        Ok(attrs)
+    }
 
-        let origin = match (lazer, using_classic_slider_acc) {
-            (false, _) => OsuScoreOrigin::Stable,
-            (true, false) => OsuScoreOrigin::WithSliderAcc {
-                max_large_ticks: attrs.n_large_ticks,
-                max_slider_ends: attrs.n_sliders,
-            },
-            (true, true) => OsuScoreOrigin::WithoutSliderAcc {
-                max_large_ticks: attrs.n_sliders + attrs.n_large_ticks,
-                max_small_ticks: attrs.n_sliders,
-            },
-        };
+    /// Same as [`OsuPerformance::calculate`] but verifies that the map was not
+    /// suspicious.
+    pub fn checked_calculate(mut self) -> Result<OsuPerformanceAttributes, CalculateError> {
+        let state = self.checked_generate_state()?;
 
-        let acc = state.hitresults.accuracy(origin);
+        // SAFETY: Attributes are calculated in `checked_generate_state`.
+        let attrs = unsafe { calculate(self, state) };
 
-        let inner =
-            OsuPerformanceCalculator::new(attrs, mods, acc, state, using_classic_slider_acc);
-
-        Ok(inner.calculate())
+        Ok(attrs)
     }
 
     pub(crate) const fn from_map_or_attrs(map_or_attrs: MapOrAttrs<'map, Osu>) -> Self {
@@ -599,6 +548,101 @@ impl<'map, T: IntoModePerformance<'map, Osu>> From<T> for OsuPerformance<'map> {
     fn from(into: T) -> Self {
         into.into_performance()
     }
+}
+
+/// # Safety
+/// Caller must ensure that the internal [`MapOrAttrs`] contains attributes.
+unsafe fn generate_state(perf: &mut OsuPerformance<'_>) -> OsuScoreState {
+    // SAFETY: Ensured by caller
+    let attrs = unsafe { perf.map_or_attrs.get_attrs() };
+
+    let inspect = Osu::inspect_performance(perf, attrs);
+
+    let total_hits = inspect.total_hits();
+    let misses = inspect.misses();
+
+    let mut hitresults = match perf.hitresult_generator {
+        Some(generator) => generator(inspect),
+        None => <Fast as HitResultGenerator<Osu>>::generate_hitresults(inspect),
+    };
+
+    let remain = total_hits.saturating_sub(hitresults.total_hits());
+
+    match perf.hitresult_priority {
+        HitResultPriority::BestCase => match (perf.n300, perf.n100, perf.n50) {
+            (None, ..) => hitresults.n300 += remain,
+            (_, None, _) => hitresults.n100 += remain,
+            (.., None) => hitresults.n50 += remain,
+            _ => hitresults.n300 += remain,
+        },
+        HitResultPriority::WorstCase => match (perf.n50, perf.n100, perf.n300) {
+            (None, ..) => hitresults.n50 += remain,
+            (_, None, _) => hitresults.n100 += remain,
+            (.., None) => hitresults.n300 += remain,
+            _ => hitresults.n50 += remain,
+        },
+    }
+
+    let max_possible_combo = attrs.max_combo.saturating_sub(misses);
+
+    let max_combo = perf.combo.map_or(max_possible_combo, |combo| {
+        cmp::min(combo, max_possible_combo)
+    });
+
+    perf.combo = Some(max_combo);
+
+    let OsuHitResults {
+        large_tick_hits,
+        small_tick_hits,
+        slider_end_hits,
+        n300,
+        n100,
+        n50,
+        misses,
+    } = &hitresults;
+
+    perf.slider_end_hits = Some(*slider_end_hits);
+    perf.large_tick_hits = Some(*large_tick_hits);
+    perf.small_tick_hits = Some(*small_tick_hits);
+    perf.n300 = Some(*n300);
+    perf.n100 = Some(*n100);
+    perf.n50 = Some(*n50);
+    perf.misses = Some(*misses);
+
+    OsuScoreState {
+        max_combo,
+        hitresults,
+        legacy_total_score: perf.legacy_total_score,
+    }
+}
+
+/// # Safety
+/// Caller must ensure that the internal [`MapOrAttrs`] contains attributes.
+unsafe fn calculate(perf: OsuPerformance<'_>, state: OsuScoreState) -> OsuPerformanceAttributes {
+    // SAFETY: Ensured by caller
+    let attrs = unsafe { perf.map_or_attrs.into_attrs() };
+
+    let mods = perf.difficulty.get_mods();
+    let lazer = perf.difficulty.get_lazer();
+    let using_classic_slider_acc = mods.no_slider_head_acc(lazer);
+
+    let origin = match (lazer, using_classic_slider_acc) {
+        (false, _) => OsuScoreOrigin::Stable,
+        (true, false) => OsuScoreOrigin::WithSliderAcc {
+            max_large_ticks: attrs.n_large_ticks,
+            max_slider_ends: attrs.n_sliders,
+        },
+        (true, true) => OsuScoreOrigin::WithoutSliderAcc {
+            max_large_ticks: attrs.n_sliders + attrs.n_large_ticks,
+            max_small_ticks: attrs.n_sliders,
+        },
+    };
+
+    let acc = state.hitresults.accuracy(origin);
+
+    let inner = OsuPerformanceCalculator::new(attrs, mods, acc, state, using_classic_slider_acc);
+
+    inner.calculate()
 }
 
 #[cfg(test)]

--- a/src/taiko/difficulty/gradual.rs
+++ b/src/taiko/difficulty/gradual.rs
@@ -4,9 +4,8 @@ use rosu_map::section::general::GameMode;
 
 use crate::{
     Beatmap, Difficulty,
-    any::difficulty::skills::StrainSkill,
+    any::{CalculateError, difficulty::skills::StrainSkill},
     model::{hit_object::HitObject, mode::ConvertError},
-    taiko::convert,
     util::sync::RefCount,
 };
 
@@ -70,69 +69,80 @@ enum FirstTwoCombos {
 impl TaikoGradualDifficulty {
     /// Create a new difficulty attributes iterator for osu!taiko maps.
     pub fn new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, ConvertError> {
-        let mut map = map.convert_ref(GameMode::Taiko, difficulty.get_mods())?;
+        let map = super::prepare_map(&difficulty, map)?;
 
-        if let Some(seed) = difficulty.get_mods().random_seed() {
-            convert::apply_random_to_beatmap(map.to_mut(), seed);
-        }
+        Ok(new(difficulty, &map))
+    }
 
-        let take = difficulty.get_passed_objects();
-        let clock_rate = difficulty.get_clock_rate();
+    /// Same as [`TaikoGradualDifficulty::new`] but verifies that the map is not
+    /// suspicious.
+    pub fn checked_new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, CalculateError> {
+        let map = super::prepare_map(&difficulty, map)?;
+        map.check_suspicion()?;
 
-        let first_combos = match (
-            map.hit_objects.first().map(HitObject::is_circle),
-            map.hit_objects.get(1).map(HitObject::is_circle),
-        ) {
-            (None, _) | (Some(false), Some(false) | None) => FirstTwoCombos::None,
-            (Some(true), Some(false) | None) => FirstTwoCombos::OnlyFirst,
-            (Some(false), Some(true)) => FirstTwoCombos::OnlySecond,
-            (Some(true), Some(true)) => FirstTwoCombos::Both,
-        };
+        Ok(new(difficulty, &map))
+    }
+}
 
-        let hit_windows = map
-            .attributes()
-            .difficulty(&difficulty)
-            .build()
-            .hit_windows();
+fn new(difficulty: Difficulty, map: &Beatmap) -> TaikoGradualDifficulty {
+    debug_assert_eq!(map.mode, GameMode::Taiko);
 
-        let great_hit_window = hit_windows.od_great.unwrap_or(0.0);
-        let ok_hit_window = hit_windows.od_ok.unwrap_or(0.0);
+    let take = difficulty.get_passed_objects();
+    let clock_rate = difficulty.get_clock_rate();
 
-        let mut n_diff_objects = 0;
-        let mut max_combo = 0;
+    let first_combos = match (
+        map.hit_objects.first().map(HitObject::is_circle),
+        map.hit_objects.get(1).map(HitObject::is_circle),
+    ) {
+        (None, _) | (Some(false), Some(false) | None) => FirstTwoCombos::None,
+        (Some(true), Some(false) | None) => FirstTwoCombos::OnlyFirst,
+        (Some(false), Some(true)) => FirstTwoCombos::OnlySecond,
+        (Some(true), Some(true)) => FirstTwoCombos::Both,
+    };
 
-        let diff_objects = DifficultyValues::create_difficulty_objects(
-            &map,
-            take as u32,
-            clock_rate,
-            &mut max_combo,
-            &mut n_diff_objects,
-            difficulty.get_mods(),
-        );
+    let hit_windows = map
+        .attributes()
+        .difficulty(&difficulty)
+        .build()
+        .hit_windows();
 
-        let skills = TaikoSkills::new(great_hit_window, map.is_convert);
+    let great_hit_window = hit_windows.od_great.unwrap_or(0.0);
+    let ok_hit_window = hit_windows.od_ok.unwrap_or(0.0);
 
-        let attrs = TaikoDifficultyAttributes {
-            great_hit_window,
-            ok_hit_window,
-            is_convert: map.is_convert,
-            ..Default::default()
-        };
+    let mut n_diff_objects = 0;
+    let mut max_combo = 0;
 
-        let total_hits = map.hit_objects.iter().filter(|h| h.is_circle()).count();
+    let diff_objects = DifficultyValues::create_difficulty_objects(
+        map,
+        take as u32,
+        clock_rate,
+        &mut max_combo,
+        &mut n_diff_objects,
+        difficulty.get_mods(),
+    );
 
-        let diff_objects_iter = extend_lifetime(diff_objects.iter());
+    let skills = TaikoSkills::new(great_hit_window, map.is_convert);
 
-        Ok(Self {
-            idx: 0,
-            difficulty,
-            diff_objects,
-            diff_objects_iter,
-            skills,
-            attrs,
-            total_hits,
-            first_combos,
-        })
+    let attrs = TaikoDifficultyAttributes {
+        great_hit_window,
+        ok_hit_window,
+        is_convert: map.is_convert,
+        ..Default::default()
+    };
+
+    let total_hits = map.hit_objects.iter().filter(|h| h.is_circle()).count();
+
+    let diff_objects_iter = extend_lifetime(diff_objects.iter());
+
+    TaikoGradualDifficulty {
+        idx: 0,
+        difficulty,
+        diff_objects,
+        diff_objects_iter,
+        skills,
+        attrs,
+        total_hits,
+        first_combos,
     }
 }
 

--- a/src/taiko/difficulty/mod.rs
+++ b/src/taiko/difficulty/mod.rs
@@ -1,4 +1,4 @@
-use std::cmp;
+use std::{borrow::Cow, cmp};
 
 use rhythm::preprocessor::RhythmDifficultyPreprocessor;
 use rosu_map::section::general::GameMode;
@@ -6,7 +6,7 @@ use skills::{color::Color, reading::Reading, rhythm::Rhythm, stamina::Stamina};
 
 use crate::{
     Beatmap, Difficulty, GameMods,
-    any::difficulty::skills::StrainSkill,
+    any::{CalculateError, difficulty::skills::StrainSkill},
     model::mode::ConvertError,
     taiko::{
         difficulty::{
@@ -44,11 +44,36 @@ pub fn difficulty(
     difficulty: &Difficulty,
     map: &Beatmap,
 ) -> Result<TaikoDifficultyAttributes, ConvertError> {
+    let map = prepare_map(difficulty, map)?;
+
+    Ok(calculate_difficulty(difficulty, &map))
+}
+
+pub fn checked_difficulty(
+    difficulty: &Difficulty,
+    map: &Beatmap,
+) -> Result<TaikoDifficultyAttributes, CalculateError> {
+    let map = prepare_map(difficulty, map)?;
+    map.check_suspicion()?;
+
+    Ok(calculate_difficulty(difficulty, &map))
+}
+
+fn prepare_map<'map>(
+    difficulty: &Difficulty,
+    map: &'map Beatmap,
+) -> Result<Cow<'map, Beatmap>, ConvertError> {
     let mut map = map.convert_ref(GameMode::Taiko, difficulty.get_mods())?;
 
     if let Some(seed) = difficulty.get_mods().random_seed() {
         convert::apply_random_to_beatmap(map.to_mut(), seed);
     }
+
+    Ok(map)
+}
+
+fn calculate_difficulty(difficulty: &Difficulty, map: &Beatmap) -> TaikoDifficultyAttributes {
+    debug_assert_eq!(map.mode, GameMode::Taiko);
 
     let hit_windows = map
         .attributes()
@@ -60,7 +85,7 @@ pub fn difficulty(
     let ok_hit_window = hit_windows.od_ok.unwrap_or(0.0);
 
     let DifficultyValues { skills, max_combo } =
-        DifficultyValues::calculate(difficulty, &map, great_hit_window);
+        DifficultyValues::calculate(difficulty, map, great_hit_window);
 
     let mut attrs = TaikoDifficultyAttributes {
         great_hit_window,
@@ -74,7 +99,7 @@ pub fn difficulty(
 
     DifficultyValues::eval(&mut attrs, skills, is_relax);
 
-    Ok(attrs)
+    attrs
 }
 
 /// Returns the combined rating and the consistency factor

--- a/src/taiko/mod.rs
+++ b/src/taiko/mod.rs
@@ -2,6 +2,7 @@ use rosu_map::section::general::GameMode;
 
 use crate::{
     Difficulty,
+    any::CalculateError,
     model::{
         beatmap::Beatmap,
         mode::{ConvertError, IGameMode},
@@ -49,6 +50,13 @@ impl IGameMode for Taiko {
         map: &Beatmap,
     ) -> Result<Self::DifficultyAttributes, ConvertError> {
         difficulty::difficulty(difficulty, map)
+    }
+
+    fn checked_difficulty(
+        difficulty: &Difficulty,
+        map: &Beatmap,
+    ) -> Result<Self::DifficultyAttributes, CalculateError> {
+        difficulty::checked_difficulty(difficulty, map)
     }
 
     fn strains(difficulty: &Difficulty, map: &Beatmap) -> Result<Self::Strains, ConvertError> {

--- a/src/taiko/performance/gradual.rs
+++ b/src/taiko/performance/gradual.rs
@@ -1,5 +1,6 @@
 use crate::{
     Beatmap, Difficulty,
+    any::CalculateError,
     model::mode::ConvertError,
     taiko::{TaikoScoreState, difficulty::gradual::TaikoGradualDifficulty},
 };
@@ -85,6 +86,14 @@ impl TaikoGradualPerformance {
     /// Create a new gradual performance calculator for osu!taiko maps.
     pub fn new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, ConvertError> {
         let difficulty = TaikoGradualDifficulty::new(difficulty, map)?;
+
+        Ok(Self { difficulty })
+    }
+
+    /// Same as [`TaikoGradualPerformance::new`] but verifies that the map is
+    /// not suspicious.
+    pub fn checked_new(difficulty: Difficulty, map: &Beatmap) -> Result<Self, CalculateError> {
+        let difficulty = TaikoGradualDifficulty::checked_new(difficulty, map)?;
 
         Ok(Self { difficulty })
     }

--- a/src/taiko/performance/mod.rs
+++ b/src/taiko/performance/mod.rs
@@ -9,7 +9,7 @@ pub use self::inspect::InspectTaikoPerformance;
 use crate::{
     Performance,
     any::{
-        Difficulty, HitResultGenerator, HitResultPriority, InspectablePerformance,
+        CalculateError, Difficulty, HitResultGenerator, HitResultPriority, InspectablePerformance,
         IntoModePerformance, IntoPerformance, hitresult_generator::Closest,
     },
     model::{mode::ConvertError, mods::GameMods},
@@ -267,53 +267,56 @@ impl<'map> TaikoPerformance<'map> {
         self
     }
 
-    /// Create the [`TaikoScoreState`] that will be used for performance calculation.
+    /// Create the [`TaikoScoreState`] that will be used for performance
+    /// calculation.
+    ///
+    /// If this [`TaikoPerformance`] contained a [`Beatmap`], it will be
+    /// replaced by [`TaikoDifficultyAttributes`].
+    ///
+    /// [`Beatmap`]: crate::Beatmap
+    /// [`TaikoDifficultyAttributes`]: crate::taiko::TaikoDifficultyAttributes
     pub fn generate_state(&mut self) -> Result<TaikoScoreState, ConvertError> {
         self.map_or_attrs.insert_attrs(&self.difficulty)?;
 
         // SAFETY: We just calculated and inserted the attributes.
-        let attrs = unsafe { self.map_or_attrs.get_attrs() };
+        let state = unsafe { generate_state(self) };
 
-        let inspect = Taiko::inspect_performance(self, attrs);
+        Ok(state)
+    }
 
-        let max_combo = inspect.max_combo();
-        let misses = inspect.misses();
+    /// Same as [`TaikoPerformance::generate_state`] but verifies that the map
+    /// is not suspicious.
+    pub fn checked_generate_state(&mut self) -> Result<TaikoScoreState, CalculateError> {
+        self.map_or_attrs.checked_insert_attrs(&self.difficulty)?;
 
-        let hitresults = match self.hitresult_generator {
-            Some(generator) => generator(inspect),
-            // Closest is still pretty quick for taiko so it should be fine
-            // to default to it rather than Fast
-            None => <Closest as HitResultGenerator<Taiko>>::generate_hitresults(inspect),
-        };
+        // SAFETY: We just calculated and inserted the attributes.
+        let state = unsafe { generate_state(self) };
 
-        let max_possible_combo = max_combo.saturating_sub(misses);
-
-        let max_combo = self.combo.map_or(max_possible_combo, |combo| {
-            cmp::min(combo, max_possible_combo)
-        });
-
-        self.combo = Some(max_combo);
-
-        let TaikoHitResults { n300, n100, misses } = hitresults;
-
-        self.n300 = Some(n300);
-        self.n100 = Some(n100);
-        self.misses = Some(misses);
-
-        Ok(TaikoScoreState {
-            max_combo,
-            hitresults,
-        })
+        Ok(state)
     }
 
     /// Calculate all performance related values, including pp and stars.
     pub fn calculate(mut self) -> Result<TaikoPerformanceAttributes, ConvertError> {
         let state = self.generate_state()?;
 
-        let attrs = match self.map_or_attrs {
-            MapOrAttrs::Attrs(attrs) => attrs,
-            MapOrAttrs::Map(ref map) => self.difficulty.calculate_for_mode::<Taiko>(map)?,
-        };
+        // SAFETY: Attributes are calculated in `generate_state`.
+        let attrs = unsafe { self.map_or_attrs.into_attrs() };
+
+        let is_classic = !self.difficulty.get_lazer() || self.difficulty.get_mods().cl();
+
+        let calculator =
+            TaikoPerformanceCalculator::new(attrs, self.difficulty.get_mods(), state, is_classic);
+
+        Ok(calculator.calculate())
+    }
+
+    /// Same as [`TaikoPerformance::calculate`] but verifies that the map was
+    /// not suspicious.
+    pub fn checked_calculate(mut self) -> Result<TaikoPerformanceAttributes, CalculateError> {
+        let state = self.checked_generate_state()?;
+
+        // SAFETY: Attributes are calculated in `checked_generate_state`.
+        let attrs = unsafe { self.map_or_attrs.into_attrs() };
 
         let is_classic = !self.difficulty.get_lazer() || self.difficulty.get_mods().cl();
 
@@ -392,6 +395,44 @@ impl<'map> TryFrom<OsuPerformance<'map>> for TaikoPerformance<'map> {
 impl<'map, T: IntoModePerformance<'map, Taiko>> From<T> for TaikoPerformance<'map> {
     fn from(into: T) -> Self {
         into.into_performance()
+    }
+}
+
+/// # Safety
+/// Caller must ensure that the internal [`MapOrAttrs`] contains attributes.
+unsafe fn generate_state(perf: &mut TaikoPerformance) -> TaikoScoreState {
+    // SAFETY: Ensured by caller
+    let attrs = unsafe { perf.map_or_attrs.get_attrs() };
+
+    let inspect = Taiko::inspect_performance(perf, attrs);
+
+    let max_combo = inspect.max_combo();
+    let misses = inspect.misses();
+
+    let hitresults = match perf.hitresult_generator {
+        Some(generator) => generator(inspect),
+        // Closest is still pretty quick for taiko so it should be fine
+        // to default to it rather than Fast
+        None => <Closest as HitResultGenerator<Taiko>>::generate_hitresults(inspect),
+    };
+
+    let max_possible_combo = max_combo.saturating_sub(misses);
+
+    let max_combo = perf.combo.map_or(max_possible_combo, |combo| {
+        cmp::min(combo, max_possible_combo)
+    });
+
+    perf.combo = Some(max_combo);
+
+    let TaikoHitResults { n300, n100, misses } = hitresults;
+
+    perf.n300 = Some(n300);
+    perf.n100 = Some(n100);
+    perf.misses = Some(misses);
+
+    TaikoScoreState {
+        max_combo,
+        hitresults,
     }
 }
 

--- a/src/util/map_or_attrs.rs
+++ b/src/util/map_or_attrs.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::{
     Beatmap, Difficulty,
+    any::CalculateError,
     model::mode::{ConvertError, IGameMode},
 };
 
@@ -16,10 +17,16 @@ pub enum MapOrAttrs<'map, M: IGameMode> {
 impl<M: IGameMode> MapOrAttrs<'_, M> {
     pub fn insert_attrs(&mut self, difficulty: &Difficulty) -> Result<(), ConvertError> {
         match self {
-            Self::Map(map) => {
-                let attrs = difficulty.calculate_for_mode::<M>(map)?;
-                *self = Self::Attrs(attrs);
-            }
+            Self::Map(map) => *self = Self::Attrs(difficulty.calculate_for_mode::<M>(map)?),
+            Self::Attrs(_) => {}
+        }
+
+        Ok(())
+    }
+
+    pub fn checked_insert_attrs(&mut self, difficulty: &Difficulty) -> Result<(), CalculateError> {
+        match self {
+            Self::Map(map) => *self = Self::Attrs(difficulty.checked_calculate_for_mode::<M>(map)?),
             Self::Attrs(_) => {}
         }
 
@@ -35,6 +42,18 @@ impl<M: IGameMode> MapOrAttrs<'_, M> {
         // as argument, unfortunately, makes it impossible to pass another
         // mutable reference later on. Instead we split it up into two
         // functions: first `insert_attrs` and then `get_attrs`.
+        match self {
+            Self::Attrs(attrs) => attrs,
+            // SAFETY: Up to the caller to uphold
+            Self::Map(_) => unsafe { std::hint::unreachable_unchecked() },
+        }
+    }
+
+    /// Get the attributes.
+    ///
+    /// # Safety
+    /// Caller must ensure that this [`MapOrAttrs`] contains attributes.
+    pub unsafe fn into_attrs(self) -> M::DifficultyAttributes {
         match self {
             Self::Attrs(attrs) => attrs,
             // SAFETY: Up to the caller to uphold


### PR DESCRIPTION
Adds various `checked_*` methods which do the same job but also verify beforehand that the used beatmap is not too suspicious for further calculation.

The hope is that it makes it a bit more convenient for users to check suspicion.

Added methods:
- `GradualDifficulty::checked_new`
- `Difficulty::{checked_calculate, checked_calculate_for_mode}`
- `GradualPerformance::checked_new`
- `Performance::{checked_calculate, checked_generate_state}`
- `{Catch, Mania, Osu, Taiko}GradualDifficulty::checked_new`
- `{Catch, Mania, Osu, Taiko}GradualPerformance::checked_new`
- `{Catch, Mania, Osu, Taiko}Performance::{checked_new, checked_generate_state}`
- `IGameMode::checked_difficulty`